### PR TITLE
Update documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ The Plugins SDK allows you to customize and extend the functionality of the [Dat
 
 ## Documentation
 
-Complete documentation of this package can be found in [DatoCMS website](https://www.datocms.com/docs/plugins/sdk-reference/).
+Complete documentation of this package can be found in [DatoCMS website](https://www.datocms.com/docs/building-plugins/sdk-reference).


### PR DESCRIPTION
The current link seems to be broken: https://www.datocms.com/docs/plugins/sdk-reference

Updated the readme to point to this link instead: https://www.datocms.com/docs/building-plugins/sdk-reference