### PR TITLE
Clarify `onBeforeItemUpsert()` hook and how it interacts with validations.

### DIFF
--- a/packages/sdk/manifest.json
+++ b/packages/sdk/manifest.json
@@ -1616,7 +1616,7 @@
     "onBeforeItemUpsert": {
       "name": "onBeforeItemUpsert",
       "comment": {
-        "markdownText": "This function will be called before saving a new version of a record. You\ncan stop the action by returning `false`.",
+        "markdownText": "This function will be called before saving a new version of a record. You\ncan stop the action by returning `false`. Doing so will intercept the Save\nbutton's handler, preventing the record save or creation.\n\nThis hooks fires BEFORE serverside validation. If you return `false`,\nnothing will get sent to our server and no serverside validation or\nsave will occur. If you return `true`, this hook will run first and then\nserverside validation & saving will continue as usual.\n\nClientside validations are not affected by this hook, since those occur\nasynchronously and independently on individual fields' onBlur() events.",
         "tag": "beforeHooks"
       },
       "nonCtxArguments": [
@@ -1642,7 +1642,7 @@
                 },
                 "location": {
                   "filePath": "src/hooks/onBeforeItemUpsert.ts",
-                  "lineNumber": 40
+                  "lineNumber": 49
                 },
                 "type": "(path: string, locale?: string) => Promise<void>"
               }
@@ -1653,7 +1653,7 @@
       "returnType": "MaybePromise<boolean>",
       "location": {
         "filePath": "src/hooks/onBeforeItemUpsert.ts",
-        "lineNumber": 15
+        "lineNumber": 24
       }
     },
     "manualFieldExtensions": {

--- a/packages/sdk/manifest.json
+++ b/packages/sdk/manifest.json
@@ -1616,7 +1616,7 @@
     "onBeforeItemUpsert": {
       "name": "onBeforeItemUpsert",
       "comment": {
-        "markdownText": "This function will be called before saving a new version of a record. You\ncan stop the action by returning `false`. Doing so will intercept the Save\nbutton's handler, preventing the record save or creation.\n\nThis hooks fires BEFORE serverside validation. If you return `false`,\nnothing will get sent to our server and no serverside validation or\nsave will occur. If you return `true`, this hook will run first and then\nserverside validation & saving will continue as usual.\n\nClientside validations are not affected by this hook, since those occur\nasynchronously and independently on individual fields' onBlur() events.",
+        "markdownText": "This hook is called when the user attempts to save a record. You can use it to block record saving.\n\nIf you return `false`, the record will NOT be saved. A small on-page error will say \"A plugin blocked the action\".\nHowever, for better UX, consider also using `ctx.alert()` to better explain to the user why their save was blocked.\n\nIf you return `true`, the save will proceed as normal.\n\nThis hook runs BEFORE serverside validation. You can use it to do your own additional validation before returning.\nClientside validations are not affected by this hook, since those occur on individual fields' `onBlur()` events.",
         "tag": "beforeHooks"
       },
       "nonCtxArguments": [
@@ -1642,7 +1642,7 @@
                 },
                 "location": {
                   "filePath": "src/hooks/onBeforeItemUpsert.ts",
-                  "lineNumber": 49
+                  "lineNumber": 47
                 },
                 "type": "(path: string, locale?: string) => Promise<void>"
               }
@@ -1653,7 +1653,7 @@
       "returnType": "MaybePromise<boolean>",
       "location": {
         "filePath": "src/hooks/onBeforeItemUpsert.ts",
-        "lineNumber": 24
+        "lineNumber": 22
       }
     },
     "manualFieldExtensions": {

--- a/packages/sdk/src/hooks/onBeforeItemUpsert.ts
+++ b/packages/sdk/src/hooks/onBeforeItemUpsert.ts
@@ -7,17 +7,15 @@ type ItemCreateSchema = SchemaTypes.ItemCreateSchema;
 
 export type OnBeforeItemUpsertHook = {
   /**
-   * This function will be called before saving a new version of a record. You
-   * can stop the action by returning `false`. Doing so will intercept the Save
-   * button's handler, preventing the record save or creation.
+   * This hook is called when the user attempts to save a record. You can use it to block record saving.
    *
-   * This hooks fires BEFORE serverside validation. If you return `false`,
-   * nothing will get sent to our server and no serverside validation or
-   * save will occur. If you return `true`, this hook will run first and then
-   * serverside validation & saving will continue as usual.
+   * If you return `false`, the record will NOT be saved. A small on-page error will say "A plugin blocked the action".
+   * However, for better UX, consider also using `ctx.alert()` to better explain to the user why their save was blocked.
    *
-   * Clientside validations are not affected by this hook, since those occur
-   * asynchronously and independently on individual fields' `onBlur()` events.
+   * If you return `true`, the save will proceed as normal.
+   *
+   * This hook runs BEFORE serverside validation. You can use it to do your own additional validation before returning.
+   * Clientside validations are not affected by this hook, since those occur on individual fields' `onBlur()` events.
    *
    * @tag beforeHooks
    */

--- a/packages/sdk/src/hooks/onBeforeItemUpsert.ts
+++ b/packages/sdk/src/hooks/onBeforeItemUpsert.ts
@@ -17,7 +17,7 @@ export type OnBeforeItemUpsertHook = {
    * serverside validation & saving will continue as usual.
    *
    * Clientside validations are not affected by this hook, since those occur
-   * asynchronously and independently on individual fields' onBlur() events.
+   * asynchronously and independently on individual fields' `onBlur()` events.
    *
    * @tag beforeHooks
    */

--- a/packages/sdk/src/hooks/onBeforeItemUpsert.ts
+++ b/packages/sdk/src/hooks/onBeforeItemUpsert.ts
@@ -8,7 +8,16 @@ type ItemCreateSchema = SchemaTypes.ItemCreateSchema;
 export type OnBeforeItemUpsertHook = {
   /**
    * This function will be called before saving a new version of a record. You
-   * can stop the action by returning `false`
+   * can stop the action by returning `false`. Doing so will intercept the Save
+   * button's handler, preventing the record save or creation.
+   *
+   * This hooks fires BEFORE serverside validation. If you return `false`,
+   * nothing will get sent to our server and no serverside validation or
+   * save will occur. If you return `true`, this hook will run first and then
+   * serverside validation & saving will continue as usual.
+   *
+   * Clientside validations are not affected by this hook, since those occur
+   * asynchronously and independently on individual fields' onBlur() events.
    *
    * @tag beforeHooks
    */

--- a/packages/sdk/src/manifest.ts
+++ b/packages/sdk/src/manifest.ts
@@ -1745,7 +1745,7 @@ export const manifest: Manifest = {
       name: 'onBeforeItemUpsert',
       comment: {
         markdownText:
-          "This function will be called before saving a new version of a record. You\ncan stop the action by returning `false`. Doing so will intercept the Save\nbutton's handler, preventing the record save or creation.\n\nThis hooks fires BEFORE serverside validation. If you return `false`,\nnothing will get sent to our server and no serverside validation or\nsave will occur. If you return `true`, this hook will run first and then\nserverside validation & saving will continue as usual.\n\nClientside validations are not affected by this hook, since those occur\nasynchronously and independently on individual fields' onBlur() events.",
+          'This hook is called when the user attempts to save a record. You can use it to block record saving.\n\nIf you return `false`, the record will NOT be saved. A small on-page error will say "A plugin blocked the action".\nHowever, for better UX, consider also using `ctx.alert()` to better explain to the user why their save was blocked.\n\nIf you return `true`, the save will proceed as normal.\n\nThis hook runs BEFORE serverside validation. You can use it to do your own additional validation before returning.\nClientside validations are not affected by this hook, since those occur on individual fields\' `onBlur()` events.',
         tag: 'beforeHooks',
       },
       nonCtxArguments: [
@@ -1773,7 +1773,7 @@ export const manifest: Manifest = {
                 },
                 location: {
                   filePath: 'src/hooks/onBeforeItemUpsert.ts',
-                  lineNumber: 49,
+                  lineNumber: 47,
                 },
                 type: '(path: string, locale?: string) => Promise<void>',
               },
@@ -1784,7 +1784,7 @@ export const manifest: Manifest = {
       returnType: 'MaybePromise<boolean>',
       location: {
         filePath: 'src/hooks/onBeforeItemUpsert.ts',
-        lineNumber: 24,
+        lineNumber: 22,
       },
     },
     manualFieldExtensions: {

--- a/packages/sdk/src/manifest.ts
+++ b/packages/sdk/src/manifest.ts
@@ -1745,7 +1745,7 @@ export const manifest: Manifest = {
       name: 'onBeforeItemUpsert',
       comment: {
         markdownText:
-          'This function will be called before saving a new version of a record. You\ncan stop the action by returning `false`.',
+          "This function will be called before saving a new version of a record. You\ncan stop the action by returning `false`. Doing so will intercept the Save\nbutton's handler, preventing the record save or creation.\n\nThis hooks fires BEFORE serverside validation. If you return `false`,\nnothing will get sent to our server and no serverside validation or\nsave will occur. If you return `true`, this hook will run first and then\nserverside validation & saving will continue as usual.\n\nClientside validations are not affected by this hook, since those occur\nasynchronously and independently on individual fields' onBlur() events.",
         tag: 'beforeHooks',
       },
       nonCtxArguments: [
@@ -1773,7 +1773,7 @@ export const manifest: Manifest = {
                 },
                 location: {
                   filePath: 'src/hooks/onBeforeItemUpsert.ts',
-                  lineNumber: 40,
+                  lineNumber: 49,
                 },
                 type: '(path: string, locale?: string) => Promise<void>',
               },
@@ -1784,7 +1784,7 @@ export const manifest: Manifest = {
       returnType: 'MaybePromise<boolean>',
       location: {
         filePath: 'src/hooks/onBeforeItemUpsert.ts',
-        lineNumber: 15,
+        lineNumber: 24,
       },
     },
     manualFieldExtensions: {


### PR DESCRIPTION
This addresses a customer question at: https://community.datocms.com/t/more-info-on-documentation-about-even-hooks/8139. They were wondering when this hook fires relative to validations. This updates our documentation for the `onBeforeItemUpsert()` hook.

