### PR TITLE
Introduce dark mode: support plugins

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,13 +1,20 @@
 module.exports = {
-  preset: 'ts-jest/presets/default-esm', // or other ESM presets
-  globals: {
-    'ts-jest': {
-      useESM: true,
-    },
-  },
+  preset: 'ts-jest/presets/default-esm',
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   testEnvironment: 'node',
-  transform: {},
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        // The repo's tsconfig compiles to CommonJS for the published builds.
+        // Jest, however, loads test modules as ESM (see the default-esm
+        // preset), so ts-jest must emit ESM too — otherwise the compiled
+        // `exports`/`require` references throw "exports is not defined".
+        tsconfig: { module: 'esnext' },
+      },
+    ],
+  },
 };

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.0.0-alpha.0"
+  "version": "3.0.1-alpha.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.1.4"
+  "version": "3.0.0-alpha.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.1.5"
+  "version": "3.0.1-alpha.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.2.0-alpha.0"
+  "version": "2.2.0-alpha.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.2.0-alpha.1"
+  "version": "2.2.0-alpha.2"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.2.0-alpha.2"
+  "version": "2.2.0-alpha.3"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.0.1-alpha.0"
+  "version": "2.2.0-alpha.0"
 }

--- a/packages/react-ui/PORTING.md
+++ b/packages/react-ui/PORTING.md
@@ -1,0 +1,321 @@
+# Porting CMS UI components into `datocms-react-ui`
+
+This guide explains **whether** a component from the DatoCMS app (`dato/cms`, under
+`src/components/ui/`) belongs in this package, and **how** to port it so it matches the
+conventions already established here.
+
+It is derived from how the existing components were actually ported. Where a rule is
+illustrated by an existing component, the CMS original and the react-ui result are both
+named so you can read the diff yourself.
+
+> **North star:** `datocms-react-ui` gives plugin authors the *chrome vocabulary* of the
+> DatoCMS interface — the structural, navigational, action, and feedback surfaces — so a
+> plugin looks and behaves natively. It is **not** a port of the CMS's data-bound editing
+> stack. We keep the *look and the interaction*, and throw away the CMS's data model,
+> form framework, routing, i18n, and global state.
+
+---
+
+## Part 1 — Should this component be ported?
+
+### 1.1 The one-line test
+
+> Port it if a plugin author building a **generic UI inside a Canvas** would reach for it,
+> and it can be expressed without the DatoCMS data model.
+
+"Chrome" = page layout, toolbars, navigation, tabs, modals/overlays/popovers, dropdown
+menus, empty states, status indicators/badges, buttons, generic form controls, spinners,
+tooltips, panels, split views.
+
+### 1.2 Coupling is a *cost*, not a veto
+
+The most important rule, and the easiest to get wrong: **do not reject a vital chrome
+component just because it imports `react-router`, `Formik`, redux, or i18n.** Those are
+implementation details we strip during the port (see Part 2.3). A toolbar is vital chrome
+even though the CMS toolbar's buttons call `history.push`. Judge by **importance to plugin
+UIs**, then pay the decoupling cost.
+
+The only true vetoes are **semantic**, not technical:
+
+| Reject when the component is fundamentally about… | Examples (do **not** port) |
+|---|---|
+| A DatoCMS **data model** entity (records, fields, item types, uploads, users, environments, roles) | `BasicItemPresentation`, `ItemType*`, `Upload*`, `MediaCard`, `Avatar`, `Username`, `EnvironmentBadge`*, `ValidityTriangle` |
+| The CMS **editing framework** itself (the structured-text editor, field arrays, the item form) | `form/SlateInput/**`, `form/RawField`, `form/FieldArray`, most of `form/*Input` |
+| Functionality the **host already exposes via `ctx`** | `Notifications` (`ctx.notice`/`alert`), `Confirm` (`ctx.openConfirm`), host-level `openModal` |
+| A one-off **internal app screen** | `Overview`, `Spotlight`, `PermissionDenied`, `UiStatus` |
+
+\* `EnvironmentBadge` is a reject, but the generic **`Badge`** underneath it is a *keep* —
+extract the primitive, drop the environment binding. This "extract the generic core" move
+is common; see Part 2.7.
+
+### 1.3 Decision checklist
+
+1. **Is it chrome?** (layout / action / nav / feedback / generic control) → continue.
+   Otherwise stop.
+2. **Strip away its CMS data binding in your head.** Is there still a useful, generic
+   component left? → continue. If nothing meaningful remains, stop.
+3. **Does the host already provide it via `ctx`?** → stop (document the `ctx` API instead).
+4. **Does react-ui already have it?** → consider *enriching* the existing component rather
+   than adding a new one (e.g. the toolbar sub-components belong on the existing
+   `Toolbar`, not a parallel component).
+5. Otherwise: **port it.** Proceed to Part 2.
+
+### 1.4 "Already exists — enrich instead of port"
+
+These already live here; new work should extend them, not duplicate them: `Button`/
+`ButtonLink`, `ButtonGroup`, `Canvas`, `Dropdown`, `Form` + `Field*`/`FormLabel`,
+`HotKey`, `Section`, `SelectField`/`SelectInput`, `SidebarPanel`, `Spinner`, `SplitView`,
+`SwitchField`/`SwitchInput`, `TextField`/`TextInput`, `TextareaField`/`TextareaInput`,
+`Toolbar` (skeleton only — `Toolbar`/`ToolbarStack`/`ToolbarTitle`/`ToolbarButton`),
+`Tooltip`, `VerticalSplit`.
+
+---
+
+## Part 2 — How to port
+
+> **Design the API against real plugin usage — then normalize.** Before fixing a
+> component's signature, look at how the *official plugins* actually use the equivalent UI
+> (`/Users/stefanoverna/dato/plugins`). Those real-world call sites are the ground truth for
+> what props and shapes a plugin author needs. **But "they use it" is not "we must support
+> it."** Now that the SDK offers an *official* component, the plugin is often the thing that
+> should be normalized toward a single standard way — not the component bent to absorb every
+> ad-hoc variation. For each usage you find, decide deliberately: is this a genuine need the
+> API must cover, or a one-off the plugin should be migrated to the standard surface?
+> Evaluate carefully; don't invent props to paper over a non-standard call site, and don't
+> blindly inherit the CMS's shape either. The goal is the *smallest* API that cleanly covers
+> the legitimate real usages.
+
+### 2.0 Mechanics & file layout
+
+One component family per directory under `src/`:
+
+```
+src/MyComponent/
+  index.tsx            // implementation, named export(s)
+  styles.module.css    // scoped styles
+```
+
+Then:
+
+- Components import the **generated JSON mapping**, never the CSS directly:
+  `import s from './styles.module.css.json';` (the `.json` is produced by the
+  `generate-cssmodules` build step — see `CLAUDE.md`).
+- Re-export from `src/index.ts`.
+- If you add a new CSS module, add it to `src/global.css` so it lands in the bundled
+  `styles.css`.
+- **Named exports, not default.** CMS uses `export default`; react-ui uses
+  `export function Button(...)`. A file may export several related symbols
+  (`Button` + `ButtonLink`, `SwitchInput` + types).
+
+### 2.1 CSS: global BEM classes → scoped CSS Modules, tokens kept verbatim
+
+CMS uses global class strings from shared SCSS; react-ui uses scoped module classes.
+
+```tsx
+// CMS                                  // react-ui
+className="SwitchInput__switch"   →     className={s.switchInput__switch}
+'button button--primary'         →     cn(styles.button, styles[`buttonType-${buttonType}`])
+```
+
+**Keep every `var(--color--…)`, `var(--spacing-…)`, `var(--shadow--…)` token exactly as
+written.** Those semantic tokens are injected at runtime by the host onto the Canvas root,
+so copying them verbatim gives automatic light/dark parity with the CMS — this is *why*
+ports look native for free. Do not hardcode hex values or re-derive colors.
+
+### 2.2 Controlled-only, no internal form/dirty state
+
+react-ui components are **pure controlled components**: state lives with the caller.
+Drop any internal value tracking that exists to serve the CMS item form.
+
+> `form/StringInput` keeps `focus`/`blur` refs and elaborate null-vs-empty coercion to
+> avoid false "dirty" states in the item form. `TextInput` (react-ui) **drops all of it** —
+> `onBlur` is a plain passthrough. Dirty-tracking is an ItemForm concern, not a generic
+> input concern.
+
+### 2.3 Decoupling checklist (the "cost" you pay)
+
+Strip each of these and replace with a plain prop:
+
+| CMS dependency | What to do |
+|---|---|
+| `form/RawField` `BaseInputComponentPropsField` (the `{id, value, disabled, name, onChange, onBlur}` discriminated union) | Replace with explicit, plain props. Don't import the union. |
+| `Formik` (`useFormik*`), `GloballyDisabledContext` | Replace with `value`/`onChange`/`disabled`/`pending`/`onSubmit` props. |
+| `ItemFormContext` / `useItemFormContext` (e.g. `localeDirection`) | Drop, or expose as an explicit prop if genuinely generic. |
+| `react-router` (`useHistory`, `useLocation`, `<Link to=>`) | Replace navigation with `onClick` and/or an `href` variant. See `ButtonLink`. |
+| `react-redux` / `ducks/*` / store queries | Drop. The data must come in via props. |
+| `react-i18next` / `FormattedMessage` / `{ i18n: string }` message objects | Replace with `ReactNode` props/children. See 2.4. |
+| `localStorage` / other global host state | Drop persistence; keep local `useState`. (`SidebarPanel` dropped its `localStorageKey` open/closed persistence.) |
+| `@datocms/cma-client` types | Drop; if a shape is needed, define a minimal local type. |
+
+### 2.4 i18n: message keys/objects → `ReactNode`
+
+```tsx
+// CMS SidebarPanel                         // react-ui SidebarPanel
+title: { i18n: string } | ReactNode    →    title?: ReactNode
+<FormattedMessage id={title.i18n} />   →    {title}
+```
+
+The author passes already-rendered content. No translation layer, no message catalogs.
+(Same move: `Label`'s `FormattedMessage` → `FormLabel`'s `children`; `BlankSlate`'s
+`renderMessage(title)` → `ReactNode`.)
+
+### 2.5 Prop naming & semantics conventions
+
+These are the conventions the existing components follow — match them.
+
+**a) `onChange` is value-first, with the event second.**
+
+```ts
+export type TextInputChangeEventHandler = (
+  newValue: string,
+  event: React.ChangeEvent<HTMLInputElement>,
+) => void;
+```
+
+CMS passes only the value (`onChange?.(e.target.value)`); react-ui passes
+`(newValue, event)` and **defines a named handler type** per component
+(`TextInputChangeEventHandler`, `SwitchInputChangeEventHandler`). Booleans for switches:
+`onChange(newValue: boolean, event)`.
+
+**b) Spread the underlying native element's attributes, plus a `...rest` escape hatch.**
+
+```ts
+// TextInput
+} & Omit<JSX.IntrinsicElements['input'], 'onChange'>;
+// SwitchInput
+extends Omit<React.HTMLAttributes<HTMLButtonElement>, 'onChange'>
+```
+
+This makes components feel like enhanced DOM elements and gives authors an escape hatch
+without us enumerating every prop.
+
+**c) `error?: boolean` as a prop, not an external wrapper class.** CMS relies on an
+ancestor `.form__field--invalid` class; react-ui takes `error` and toggles its own scoped
+modifier (`TextInput`, `FormLabel`, `SelectInput`).
+
+**d) Prefer enums over ambiguous booleans when it clarifies intent.**
+
+```ts
+// CMS Spinner            // react-ui Spinner
+inline?: boolean    →     placement?: 'inline' | 'centered'
+```
+
+**e) Drop CMS-domain flags.** `treatFalseValueAsDeactivatedTrue`, `readOnly`, `localized`,
+`renderDropdown`/`renderInfo` (Label) — none survive into react-ui. Keep the generic
+surface only.
+
+**f) Accessibility is upgraded during the port, not preserved.** `form/SwitchInput` is a
+hidden `<input type="checkbox">` + `<label>`; react-ui's `SwitchInput` is a
+`<button role="switch" aria-checked>` with `ArrowLeft`/`ArrowRight` keyboard handling.
+When you re-implement, add roles/aria/keyboard. `TextInput` adds `labelText` → `aria-label`.
+
+### 2.6 Naming: framework-neutral and clearer
+
+| CMS | react-ui | Why |
+|---|---|---|
+| `StringInput` | `TextInput` | Plain DOM vocabulary, not the CMS field-type name |
+| `form/SwitchInput` (with built-in label) | `SwitchInput` (bare) + `SwitchField` (labeled) | Input/Field split, see 2.7 |
+| `Label` | `FormLabel` | Disambiguate from HTML `<label>` / data labels |
+| global `button--*` classes / `SubmitButton` | `Button` + `ButtonLink` | A real component; `href` variant replaces router `Link` |
+| `Toolbar.AddNewButton` (router) | `Toolbar` sub-component taking `onClick`/`href` | Decoupled action |
+
+### 2.7 Two recurring structural moves
+
+**a) Input (bare control) vs Field (labeled composite).** CMS often bakes the label into
+the input and assembles the rest via `RawField`/`Field.tsx`. react-ui splits every form
+control into two exported components:
+
+- `XxxInput` — just the control (`value`, `onChange`, native attrs).
+- `XxxField` — composes `XxxInput` + `FormLabel` + `FieldHint` + `FieldError`.
+
+`XxxField` follows a fixed prop shape:
+
+```ts
+type SwitchFieldProps = {
+  id: string;
+  name: string;
+  label: ReactNode;
+  hint?: ReactNode;
+  error?: ReactNode;
+  required?: boolean;
+  formLabelProps?: FormLabelProps;
+  value: SwitchInputProps['value'];
+  onChange: SwitchInputProps['onChange'];
+  switchInputProps?: SwitchInputProps;   // passthrough to the inner control
+};
+```
+
+Note the `xxxInputProps` **passthrough object** and the reuse of the inner component's prop
+types (`SwitchInputProps['value']`). Mirror this for any new field.
+
+**b) Generalize to the visual/behavioral core.** When a CMS component is mostly
+domain logic wrapped around a small presentational shell, **keep the shell, discard the
+logic.**
+
+> `form/FieldHint` in CMS is ~190 lines: validator introspection, `react-router`, date
+> formatting, localization settings, i18n. react-ui's `FieldHint` is the shell that
+> survived:
+> ```tsx
+> export function FieldHint({ children }: { children: ReactNode }) {
+>   return <div className={s.fieldHint}>{children}</div>;
+> }
+> ```
+> The validation logic was a CMS concern; the *look of a hint* was the chrome. Port the look.
+
+### 2.8 Re-architecting against a standard library is allowed
+
+A port doesn't have to mirror the CMS implementation — match the *behavior and look*, pick
+the best implementation for a standalone library.
+
+> CMS `Tooltip` is built on a bespoke `Overlay` + `usehooks-ts` `useHover` +
+> `useDebounceOnBoolean`, using render-props / `cloneElement`. react-ui's `Tooltip` was
+> **rebuilt on `@floating-ui/react`** (already a dependency) as a **compound component**
+> (`TooltipTrigger` / `TooltipContent` / `TooltipDelayGroup`). Prefer compound components
+> with a `Trigger`/`Content` shape for overlay-like UI over render-prop APIs.
+
+### 2.9 Portals must re-enter the Canvas
+
+Anything rendered through a portal (modal, tooltip, popover, overlay) escapes the Canvas
+DOM subtree and therefore **loses the injected CSS custom properties**. Re-wrap portalled
+content so the tokens are present again — react-ui's `Tooltip` renders its content inside a
+`<Canvas>`/shared portal root for exactly this reason. Budget for this whenever you port
+`Modal`/`Overlay`/`Popover` (and the `Portal`/`NewZIndex`/`useModalClose` helpers they need).
+
+### 2.10 Document with a Canvas `@example`
+
+Public components carry JSDoc `@example` blocks that render inside `<Canvas ctx={ctx}>`
+(see `Button`, `SidebarPanel`, `Spinner`). These are extracted into `types.json` by
+TypeDoc and power the docs site, so every exported component should have at least one
+runnable example wrapped in a Canvas.
+
+### 2.11 Modernize while you're in there
+
+Ports drop dead/legacy code: react-ui `Spinner` removed the vendor-prefixed
+`WebkitAnimationDelay`/`WebkitTransform` and the unused `...other` passthrough that the CMS
+version carried. Don't faithfully copy cruft.
+
+---
+
+## Part 3 — Port checklist (paste into the PR)
+
+**Decision**
+- [ ] It's chrome, and a generic component survives stripping the CMS data model (Part 1.1–1.3)
+- [ ] Not already provided by `ctx`; not a reject category (1.2)
+- [ ] Not already in react-ui — or this PR *enriches* the existing one (1.4)
+
+**Implementation**
+- [ ] API checked against real usage in official plugins (`dato/plugins`); non-standard call sites flagged to normalize rather than props invented to absorb them (Part 2 preface)
+- [ ] `src/MyComponent/{index.tsx,styles.module.css}`; imports `./styles.module.css.json`
+- [ ] **Named** export(s); re-exported from `src/index.ts`; CSS added to `global.css`
+- [ ] Global BEM classes → scoped module classes; **all semantic tokens kept verbatim** (2.1)
+- [ ] Pure controlled; no Formik/RawField/ItemForm/router/redux/i18n/localStorage left (2.2–2.4)
+- [ ] `onChange(newValue, event)` with a named handler type; native attrs spread + `...rest` (2.5a–b)
+- [ ] `error?: boolean`; enums over ambiguous booleans; CMS-domain flags dropped (2.5c–e)
+- [ ] a11y added (roles/aria/keyboard) (2.5f)
+- [ ] Framework-neutral name; Input/Field split with `xxxInputProps` passthrough if a control (2.6–2.7a)
+- [ ] Generalized to the presentational core; cruft removed (2.7b, 2.11)
+- [ ] Portalled content re-wrapped in Canvas (2.9, if applicable)
+- [ ] JSDoc `@example` in a `<Canvas ctx={ctx}>` (2.10)
+- [ ] `npm run build` passes (regenerates css-module JSON, types, bundle)
+</content>
+</invoke>

--- a/packages/react-ui/UPGRADING.md
+++ b/packages/react-ui/UPGRADING.md
@@ -1,0 +1,76 @@
+# Upgrading datocms-react-ui
+
+## v3.0.0 — Semantic color tokens and dark-mode support
+
+This release reworks the color system around the host's semantic color
+tokens. The CMS now computes a full color palette for the active theme
+(including dark mode), and `datocms-react-ui` consumes it directly. All
+built-in components automatically adapt to whichever theme the user has
+selected.
+
+### Action required
+
+**Test your plugin in dark mode before publishing.** Upgrading to v3 opts
+your plugin into the host's active theme. If the user has dark mode
+enabled, your plugin renders with dark colors.
+
+Common things to audit:
+
+- **Hardcoded colors** in your CSS (e.g. `color: #333`, `background: white`).
+  They won't follow the theme; users in dark mode will see them as-is and
+  the contrast may break.
+- **Hardcoded SVG fills** in custom icons. Use `fill="currentColor"` so they
+  inherit the surrounding `color`.
+- **Custom CSS that mixes library components with your own colors.** Verify
+  the combinations look right in both themes.
+
+### What's new
+
+A new set of CSS custom properties is available inside `<Canvas>`. They
+follow the host's active theme:
+
+- `--color--surface`, `--color--surface-hover`, `--color--surface-muted`, …
+- `--color--ink`, `--color--ink-subtle`, `--color--ink-placeholder`,
+  `--color--ink-accent`, …
+- `--color--border`, `--color--border-hover`
+- Per-context variants: `--color--primary--surface`, `--color--primary--ink`,
+  `--color--tinted--surface`, `--color--accent--ink`,
+  `--color--selected--surface`, `--color--disabled--surface`,
+  `--color--danger--surface`, …
+- Feedback: `--color--feedback-fail--ink`,
+  `--color--feedback-warning--surface`, `--color--feedback-success--ink`, …
+- Plus diff, status, overlay, stacked, progress, tooltip, code and shadow
+  groups.
+
+See the `Canvas` JSDoc for the full reference.
+
+All built-in components (`Button`, `Dropdown`, `Section`, `TextInput`,
+`SwitchInput`, `Toolbar`, `Tooltip`, …) now use these tokens. Built-in
+icons render with `fill="currentColor"` and inherit the surrounding
+`color`.
+
+### Deprecated CSS variables
+
+Two groups of legacy color variables remain available for backward
+compatibility, but **both are deprecated and will be removed in a future
+major version**. Migrate everything to the `--color--*` semantic tokens.
+
+**Structural legacy vars** — defined inside `<Canvas>` (e.g.
+`--border-color`, `--base-body-color`, `--light-bg-color`, `--alert-color`,
+`--add-color`, `--remove-color`, …). Each one now resolves to the closest
+semantic token first, falling back to its original light-mode value if the
+token is unavailable. So a v3 plugin that still uses them will follow the
+active theme.
+
+**Theme-derived legacy vars** — `--accent-color`, `--primary-color`,
+`--light-color`, `--dark-color`, `--semi-transparent-accent-color` (plus
+their `*-rgb-components` counterparts). These are emitted from the
+deprecated `ctx.theme` field, which the host now pins to **light values
+only**, regardless of the active theme. Mixing these with the new
+`--color--*` tokens in dark mode will produce a light accent on a dark
+surface — visibly mismatched. Replace them with the corresponding
+semantic tokens (`--color--accent--surface`, `--color--accent--ink`,
+`--color--primary--surface`, etc.).
+
+Non-color tokens (`--spacing-*`, `--font-size-*`, `--font-weight-bold`,
+`--material-ease`, font families) are stable and remain available.

--- a/packages/react-ui/UPGRADING.md
+++ b/packages/react-ui/UPGRADING.md
@@ -1,6 +1,6 @@
 # Upgrading datocms-react-ui
 
-## v3.0.0 — Semantic color tokens and dark-mode support
+## v2.2.0 — Semantic color tokens and dark-mode support
 
 This release reworks the color system around the host's semantic color
 tokens. The CMS now computes a full color palette for the active theme

--- a/packages/react-ui/UPGRADING.md
+++ b/packages/react-ui/UPGRADING.md
@@ -51,13 +51,26 @@ icons render with `fill="currentColor"` and inherit the surrounding
 
 ### Deprecated CSS variables
 
-The legacy color custom properties (`--border-color`, `--base-body-color`,
-`--alert-color`, `--add-color`, etc.) are still defined for backward
-compatibility. Each one now resolves to the closest semantic token first,
-falling back to its original light-mode value if the token is unavailable.
+Two groups of legacy color variables remain available for backward
+compatibility, but **both are deprecated and will be removed in a future
+major version**. Migrate everything to the `--color--*` semantic tokens.
 
-These will be removed in a future major version. Migrate to the
-`--color--*` tokens documented above.
+**Structural legacy vars** — defined inside `<Canvas>` (e.g.
+`--border-color`, `--base-body-color`, `--light-bg-color`, `--alert-color`,
+`--add-color`, `--remove-color`, …). Each one now resolves to the closest
+semantic token first, falling back to its original light-mode value if the
+token is unavailable. So a v3 plugin that still uses them will follow the
+active theme.
+
+**Theme-derived legacy vars** — `--accent-color`, `--primary-color`,
+`--light-color`, `--dark-color`, `--semi-transparent-accent-color` (plus
+their `*-rgb-components` counterparts). These are emitted from the
+deprecated `ctx.theme` field, which the host now pins to **light values
+only**, regardless of the active theme. Mixing these with the new
+`--color--*` tokens in dark mode will produce a light accent on a dark
+surface — visibly mismatched. Replace them with the corresponding
+semantic tokens (`--color--accent--surface`, `--color--accent--ink`,
+`--color--primary--surface`, etc.).
 
 Non-color tokens (`--spacing-*`, `--font-size-*`, `--font-weight-bold`,
 `--material-ease`, font families) are stable and remain available.

--- a/packages/react-ui/UPGRADING.md
+++ b/packages/react-ui/UPGRADING.md
@@ -31,14 +31,14 @@ follow the host's active theme:
 
 - `--color--surface`, `--color--surface-hover`, `--color--surface-muted`, …
 - `--color--ink`, `--color--ink-subtle`, `--color--ink-placeholder`,
-  `--color--ink-accent`, …
+  `--color--ink-link`, `--color--ink-danger`, …
 - `--color--border`, `--color--border-hover`
 - Per-context variants: `--color--primary--surface`, `--color--primary--ink`,
-  `--color--tinted--surface`, `--color--accent--ink`,
+  `--color--primary--surface-secondary`, `--color--primary-soft--surface`,
   `--color--selected--surface`, `--color--disabled--surface`,
   `--color--danger--surface`, …
-- Feedback: `--color--feedback-fail--ink`,
-  `--color--feedback-warning--surface`, `--color--feedback-success--ink`, …
+- Signal tones: `--color--danger-soft--surface`,
+  `--color--warning-soft--surface`, `--color--success-soft--ink`, …
 - Plus diff, status, overlay, stacked, progress, tooltip, code and shadow
   groups.
 
@@ -69,7 +69,7 @@ deprecated `ctx.theme` field, which the host now pins to **light values
 only**, regardless of the active theme. Mixing these with the new
 `--color--*` tokens in dark mode will produce a light accent on a dark
 surface — visibly mismatched. Replace them with the corresponding
-semantic tokens (`--color--accent--surface`, `--color--accent--ink`,
+semantic tokens (`--color--primary--surface-secondary`, `--color--primary--ink`,
 `--color--primary--surface`, etc.).
 
 Non-color tokens (`--spacing-*`, `--font-size-*`, `--font-weight-bold`,

--- a/packages/react-ui/UPGRADING.md
+++ b/packages/react-ui/UPGRADING.md
@@ -1,0 +1,63 @@
+# Upgrading datocms-react-ui
+
+## v3.0.0 — Semantic color tokens and dark-mode support
+
+This release reworks the color system around the host's semantic color
+tokens. The CMS now computes a full color palette for the active theme
+(including dark mode), and `datocms-react-ui` consumes it directly. All
+built-in components automatically adapt to whichever theme the user has
+selected.
+
+### Action required
+
+**Test your plugin in dark mode before publishing.** Upgrading to v3 opts
+your plugin into the host's active theme. If the user has dark mode
+enabled, your plugin renders with dark colors.
+
+Common things to audit:
+
+- **Hardcoded colors** in your CSS (e.g. `color: #333`, `background: white`).
+  They won't follow the theme; users in dark mode will see them as-is and
+  the contrast may break.
+- **Hardcoded SVG fills** in custom icons. Use `fill="currentColor"` so they
+  inherit the surrounding `color`.
+- **Custom CSS that mixes library components with your own colors.** Verify
+  the combinations look right in both themes.
+
+### What's new
+
+A new set of CSS custom properties is available inside `<Canvas>`. They
+follow the host's active theme:
+
+- `--color--surface`, `--color--surface-hover`, `--color--surface-muted`, …
+- `--color--ink`, `--color--ink-subtle`, `--color--ink-placeholder`,
+  `--color--ink-accent`, …
+- `--color--border`, `--color--border-hover`
+- Per-context variants: `--color--primary--surface`, `--color--primary--ink`,
+  `--color--tinted--surface`, `--color--accent--ink`,
+  `--color--selected--surface`, `--color--disabled--surface`,
+  `--color--danger--surface`, …
+- Feedback: `--color--feedback-fail--ink`,
+  `--color--feedback-warning--surface`, `--color--feedback-success--ink`, …
+- Plus diff, status, overlay, stacked, progress, tooltip, code and shadow
+  groups.
+
+See the `Canvas` JSDoc for the full reference.
+
+All built-in components (`Button`, `Dropdown`, `Section`, `TextInput`,
+`SwitchInput`, `Toolbar`, `Tooltip`, …) now use these tokens. Built-in
+icons render with `fill="currentColor"` and inherit the surrounding
+`color`.
+
+### Deprecated CSS variables
+
+The legacy color custom properties (`--border-color`, `--base-body-color`,
+`--alert-color`, `--add-color`, etc.) are still defined for backward
+compatibility. Each one now resolves to the closest semantic token first,
+falling back to its original light-mode value if the token is unavailable.
+
+These will be removed in a future major version. Migrate to the
+`--color--*` tokens documented above.
+
+Non-color tokens (`--spacing-*`, `--font-size-*`, `--font-weight-bold`,
+`--material-ease`, font families) are stable and remain available.

--- a/packages/react-ui/__tests__/index.test.ts
+++ b/packages/react-ui/__tests__/index.test.ts
@@ -9,7 +9,7 @@ const baseCtx = {
     lightColor: 'rgb(219, 234, 254)',
     darkColor: 'rgb(0, 33, 90)',
   },
-  semanticColorTokensTheme: {},
+  cssDesignTokens: {},
 };
 
 describe('generateStyleFromCtx', () => {
@@ -33,7 +33,7 @@ describe('generateStyleFromCtx', () => {
   it('applies semantic color tokens verbatim, keyed by their CSS variable name', () => {
     const ctx = {
       ...baseCtx,
-      semanticColorTokensTheme: {
+      cssDesignTokens: {
         '--color--surface': 'rgb(255, 255, 255)',
         '--color--ink': 'rgb(52, 54, 58)',
         '--color--ink-danger': 'rgb(255, 94, 73)',
@@ -53,8 +53,8 @@ describe('generateStyleFromCtx', () => {
     expect(style['--color--ink-rgb-components']).toBeUndefined();
   });
 
-  it('works when semanticColorTokensTheme is undefined', () => {
-    const { semanticColorTokensTheme, ...ctx } = baseCtx;
+  it('works when cssDesignTokens is undefined', () => {
+    const { cssDesignTokens, ...ctx } = baseCtx;
     const style = generateStyleFromCtx(ctx as any) as any;
 
     expect(style['--primary-color']).toBe('rgb(0, 76, 209)');
@@ -62,10 +62,10 @@ describe('generateStyleFromCtx', () => {
     expect(style['--color--surface']).toBeUndefined();
   });
 
-  it('works when semanticColorTokensTheme is an empty object', () => {
+  it('works when cssDesignTokens is an empty object', () => {
     const ctx = {
       ...baseCtx,
-      semanticColorTokensTheme: {},
+      cssDesignTokens: {},
     };
 
     const style = generateStyleFromCtx(ctx as any) as any;
@@ -80,7 +80,7 @@ describe('generateStyleFromCtx', () => {
   it('forwards arbitrary host tokens the SDK has never heard of', () => {
     const ctx = {
       ...baseCtx,
-      semanticColorTokensTheme: {
+      cssDesignTokens: {
         '--color--brand-new--surface': 'rgb(100, 200, 50)',
       },
     };

--- a/packages/react-ui/__tests__/index.test.ts
+++ b/packages/react-ui/__tests__/index.test.ts
@@ -1,5 +1,88 @@
-describe('connect()', () => {
-  it('works', () => {
-    expect(true).toBeTruthy();
+import { generateStyleFromCtx } from '../src/generateStyleFromCtx';
+
+const baseCtx = {
+  bodyPadding: [10, 20, 10, 20] as [number, number, number, number],
+  theme: {
+    primaryColor: 'rgb(0, 76, 209)',
+    accentColor: 'rgb(0, 76, 209)',
+    semiTransparentAccentColor: 'rgb(0, 76, 209)',
+    lightColor: 'rgb(219, 234, 254)',
+    darkColor: 'rgb(0, 33, 90)',
+  },
+  semanticColorTokensTheme: {},
+};
+
+describe('generateStyleFromCtx', () => {
+  it('generates existing theme CSS variables with RGB components', () => {
+    const style = generateStyleFromCtx(baseCtx as any) as any;
+
+    expect(style['--primary-color']).toBe('rgb(0, 76, 209)');
+    expect(style['--primary-color-rgb-components']).toBe('0, 76, 209');
+    expect(style['--accent-color']).toBe('rgb(0, 76, 209)');
+    expect(style['--semi-transparent-accent-color']).toBe('rgb(0, 76, 209)');
+    expect(style.padding).toBe('10px 20px 10px 20px');
+  });
+
+  it('respects noBodyPadding flag', () => {
+    const style = generateStyleFromCtx(baseCtx as any, true) as any;
+
+    expect(style.padding).toBeUndefined();
+    expect(style['--primary-color']).toBe('rgb(0, 76, 209)');
+  });
+
+  it('generates semantic color token CSS variables without RGB components', () => {
+    const ctx = {
+      ...baseCtx,
+      semanticColorTokensTheme: {
+        colorSurface: 'rgb(255, 255, 255)',
+        colorInk: 'rgb(52, 54, 58)',
+        colorFeedbackFailInk: 'rgb(255, 94, 73)',
+      },
+    };
+
+    const style = generateStyleFromCtx(ctx as any) as any;
+
+    expect(style['--color--surface']).toBe('rgb(255, 255, 255)');
+    expect(style['--color--ink']).toBe('rgb(52, 54, 58)');
+    expect(style['--color--feedback-fail--ink']).toBe('rgb(255, 94, 73)');
+
+    // No RGB components for semantic tokens
+    expect(style['--color--surface-rgb-components']).toBeUndefined();
+    expect(style['--color--ink-rgb-components']).toBeUndefined();
+  });
+
+  it('works when semanticColorTokensTheme is undefined', () => {
+    const style = generateStyleFromCtx(baseCtx as any) as any;
+
+    expect(style['--primary-color']).toBe('rgb(0, 76, 209)');
+    // Should not throw, no semantic token variables present
+    expect(style['--color--surface']).toBeUndefined();
+  });
+
+  it('works when semanticColorTokensTheme is an empty object', () => {
+    const ctx = {
+      ...baseCtx,
+      semanticColorTokensTheme: {},
+    };
+
+    const style = generateStyleFromCtx(ctx as any) as any;
+
+    expect(style['--primary-color']).toBe('rgb(0, 76, 209)');
+    const semanticKeys = Object.keys(style).filter((k: string) => k.startsWith('--color--'));
+    expect(semanticKeys).toHaveLength(0);
+  });
+
+  it('handles unknown future tokens via the Record<string, string> signature', () => {
+    const ctx = {
+      ...baseCtx,
+      semanticColorTokensTheme: {
+        colorSomeFutureToken: 'rgb(100, 200, 50)',
+      },
+    };
+
+    const style = generateStyleFromCtx(ctx as any) as any;
+
+    // Unknown tokens fall back to camelToDash (single-dash)
+    expect(style['--color-some-future-token']).toBe('rgb(100, 200, 50)');
   });
 });

--- a/packages/react-ui/__tests__/index.test.ts
+++ b/packages/react-ui/__tests__/index.test.ts
@@ -1,5 +1,93 @@
-describe('connect()', () => {
-  it('works', () => {
-    expect(true).toBeTruthy();
+import { generateStyleFromCtx } from '../src/generateStyleFromCtx';
+
+const baseCtx = {
+  bodyPadding: [10, 20, 10, 20] as [number, number, number, number],
+  theme: {
+    primaryColor: 'rgb(0, 76, 209)',
+    accentColor: 'rgb(0, 76, 209)',
+    semiTransparentAccentColor: 'rgb(0, 76, 209)',
+    lightColor: 'rgb(219, 234, 254)',
+    darkColor: 'rgb(0, 33, 90)',
+  },
+  semanticColorTokensTheme: {},
+};
+
+describe('generateStyleFromCtx', () => {
+  it('generates existing theme CSS variables with RGB components', () => {
+    const style = generateStyleFromCtx(baseCtx as any) as any;
+
+    expect(style['--primary-color']).toBe('rgb(0, 76, 209)');
+    expect(style['--primary-color-rgb-components']).toBe('0, 76, 209');
+    expect(style['--accent-color']).toBe('rgb(0, 76, 209)');
+    expect(style['--semi-transparent-accent-color']).toBe('rgb(0, 76, 209)');
+    expect(style.padding).toBe('10px 20px 10px 20px');
+  });
+
+  it('respects noBodyPadding flag', () => {
+    const style = generateStyleFromCtx(baseCtx as any, true) as any;
+
+    expect(style.padding).toBeUndefined();
+    expect(style['--primary-color']).toBe('rgb(0, 76, 209)');
+  });
+
+  it('applies semantic color tokens verbatim, keyed by their CSS variable name', () => {
+    const ctx = {
+      ...baseCtx,
+      semanticColorTokensTheme: {
+        '--color--surface': 'rgb(255, 255, 255)',
+        '--color--ink': 'rgb(52, 54, 58)',
+        '--color--feedback-fail--ink': 'rgb(255, 94, 73)',
+        '--shadow--raised': '0 1px 2px rgba(0, 0, 0, 0.1)',
+      },
+    };
+
+    const style = generateStyleFromCtx(ctx as any) as any;
+
+    expect(style['--color--surface']).toBe('rgb(255, 255, 255)');
+    expect(style['--color--ink']).toBe('rgb(52, 54, 58)');
+    expect(style['--color--feedback-fail--ink']).toBe('rgb(255, 94, 73)');
+    expect(style['--shadow--raised']).toBe('0 1px 2px rgba(0, 0, 0, 0.1)');
+
+    // Semantic tokens are passed through as-is — no RGB-component derivation.
+    expect(style['--color--surface-rgb-components']).toBeUndefined();
+    expect(style['--color--ink-rgb-components']).toBeUndefined();
+  });
+
+  it('works when semanticColorTokensTheme is undefined', () => {
+    const { semanticColorTokensTheme, ...ctx } = baseCtx;
+    const style = generateStyleFromCtx(ctx as any) as any;
+
+    expect(style['--primary-color']).toBe('rgb(0, 76, 209)');
+    // Should not throw, no semantic token variables present
+    expect(style['--color--surface']).toBeUndefined();
+  });
+
+  it('works when semanticColorTokensTheme is an empty object', () => {
+    const ctx = {
+      ...baseCtx,
+      semanticColorTokensTheme: {},
+    };
+
+    const style = generateStyleFromCtx(ctx as any) as any;
+
+    expect(style['--primary-color']).toBe('rgb(0, 76, 209)');
+    const semanticKeys = Object.keys(style).filter((k: string) =>
+      k.startsWith('--color--'),
+    );
+    expect(semanticKeys).toHaveLength(0);
+  });
+
+  it('forwards arbitrary host tokens the SDK has never heard of', () => {
+    const ctx = {
+      ...baseCtx,
+      semanticColorTokensTheme: {
+        '--color--brand-new--surface': 'rgb(100, 200, 50)',
+      },
+    };
+
+    const style = generateStyleFromCtx(ctx as any) as any;
+
+    // The SDK keeps no token list: whatever the host sends is applied as-is.
+    expect(style['--color--brand-new--surface']).toBe('rgb(100, 200, 50)');
   });
 });

--- a/packages/react-ui/__tests__/index.test.ts
+++ b/packages/react-ui/__tests__/index.test.ts
@@ -36,7 +36,7 @@ describe('generateStyleFromCtx', () => {
       semanticColorTokensTheme: {
         '--color--surface': 'rgb(255, 255, 255)',
         '--color--ink': 'rgb(52, 54, 58)',
-        '--color--feedback-fail--ink': 'rgb(255, 94, 73)',
+        '--color--ink-danger': 'rgb(255, 94, 73)',
         '--shadow--raised': '0 1px 2px rgba(0, 0, 0, 0.1)',
       },
     };
@@ -45,7 +45,7 @@ describe('generateStyleFromCtx', () => {
 
     expect(style['--color--surface']).toBe('rgb(255, 255, 255)');
     expect(style['--color--ink']).toBe('rgb(52, 54, 58)');
-    expect(style['--color--feedback-fail--ink']).toBe('rgb(255, 94, 73)');
+    expect(style['--color--ink-danger']).toBe('rgb(255, 94, 73)');
     expect(style['--shadow--raised']).toBe('0 1px 2px rgba(0, 0, 0, 0.1)');
 
     // Semantic tokens are passed through as-is — no RGB-component derivation.

--- a/packages/react-ui/package-lock.json
+++ b/packages/react-ui/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "datocms-react-ui",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.1-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-react-ui",
-      "version": "3.0.0-alpha.0",
+      "version": "3.0.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
         "classnames": "^2.3.1",
-        "datocms-plugin-sdk": "^3.0.0-alpha.0",
+        "datocms-plugin-sdk": "^3.0.1-alpha.0",
         "react-intersection-observer": "^8.31.0",
         "react-select": "^5.2.1",
         "scroll-into-view-if-needed": "^2.2.20"

--- a/packages/react-ui/package-lock.json
+++ b/packages/react-ui/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "datocms-react-ui",
-  "version": "2.1.5",
+  "version": "3.0.1-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-react-ui",
-      "version": "2.1.5",
+      "version": "3.0.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
         "classnames": "^2.3.1",
-        "datocms-plugin-sdk": "^2.1.5",
+        "datocms-plugin-sdk": "^3.0.1-alpha.0",
         "react-intersection-observer": "^8.31.0",
         "react-select": "^5.2.1",
         "scroll-into-view-if-needed": "^2.2.20"

--- a/packages/react-ui/package-lock.json
+++ b/packages/react-ui/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "datocms-react-ui",
-  "version": "2.2.0-alpha.2",
+  "version": "2.2.0-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-react-ui",
-      "version": "2.2.0-alpha.2",
+      "version": "2.2.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
         "classnames": "^2.3.1",
-        "datocms-plugin-sdk": "^2.2.0-alpha.2",
+        "datocms-plugin-sdk": "^2.2.0-alpha.3",
         "react-intersection-observer": "^8.31.0",
         "react-select": "^5.2.1",
         "scroll-into-view-if-needed": "^2.2.20"

--- a/packages/react-ui/package-lock.json
+++ b/packages/react-ui/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "datocms-react-ui",
-  "version": "2.2.0-alpha.1",
+  "version": "2.2.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-react-ui",
-      "version": "2.2.0-alpha.1",
+      "version": "2.2.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
         "classnames": "^2.3.1",
-        "datocms-plugin-sdk": "^2.2.0-alpha.1",
+        "datocms-plugin-sdk": "^2.2.0-alpha.2",
         "react-intersection-observer": "^8.31.0",
         "react-select": "^5.2.1",
         "scroll-into-view-if-needed": "^2.2.20"

--- a/packages/react-ui/package-lock.json
+++ b/packages/react-ui/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "datocms-react-ui",
-  "version": "3.0.1-alpha.0",
+  "version": "2.2.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-react-ui",
-      "version": "3.0.1-alpha.0",
+      "version": "2.2.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
         "classnames": "^2.3.1",
-        "datocms-plugin-sdk": "^3.0.1-alpha.0",
+        "datocms-plugin-sdk": "^2.2.0-alpha.0",
         "react-intersection-observer": "^8.31.0",
         "react-select": "^5.2.1",
         "scroll-into-view-if-needed": "^2.2.20"

--- a/packages/react-ui/package-lock.json
+++ b/packages/react-ui/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "datocms-react-ui",
-  "version": "2.1.4",
+  "version": "3.0.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-react-ui",
-      "version": "2.1.4",
+      "version": "3.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
         "classnames": "^2.3.1",
-        "datocms-plugin-sdk": "^2.1.1",
+        "datocms-plugin-sdk": "^3.0.0-alpha.0",
         "react-intersection-observer": "^8.31.0",
         "react-select": "^5.2.1",
         "scroll-into-view-if-needed": "^2.2.20"

--- a/packages/react-ui/package-lock.json
+++ b/packages/react-ui/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "datocms-react-ui",
-  "version": "2.2.0-alpha.0",
+  "version": "2.2.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-react-ui",
-      "version": "2.2.0-alpha.0",
+      "version": "2.2.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
         "classnames": "^2.3.1",
-        "datocms-plugin-sdk": "^2.2.0-alpha.0",
+        "datocms-plugin-sdk": "^2.2.0-alpha.1",
         "react-intersection-observer": "^8.31.0",
         "react-select": "^5.2.1",
         "scroll-into-view-if-needed": "^2.2.20"

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-react-ui",
-  "version": "2.1.5",
+  "version": "3.0.1-alpha.0",
   "description": "React components to use inside DatoCMS plugins",
   "keywords": [
     "datocms",
@@ -42,7 +42,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.27.16",
     "classnames": "^2.3.1",
-    "datocms-plugin-sdk": "^2.1.5",
+    "datocms-plugin-sdk": "^3.0.1-alpha.0",
     "react-intersection-observer": "^8.31.0",
     "react-select": "^5.2.1",
     "scroll-into-view-if-needed": "^2.2.20"

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-react-ui",
-  "version": "3.0.1-alpha.0",
+  "version": "2.2.0-alpha.0",
   "description": "React components to use inside DatoCMS plugins",
   "keywords": [
     "datocms",
@@ -42,7 +42,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.27.16",
     "classnames": "^2.3.1",
-    "datocms-plugin-sdk": "^3.0.1-alpha.0",
+    "datocms-plugin-sdk": "^2.2.0-alpha.0",
     "react-intersection-observer": "^8.31.0",
     "react-select": "^5.2.1",
     "scroll-into-view-if-needed": "^2.2.20"

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-react-ui",
-  "version": "2.2.0-alpha.0",
+  "version": "2.2.0-alpha.1",
   "description": "React components to use inside DatoCMS plugins",
   "keywords": [
     "datocms",
@@ -42,7 +42,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.27.16",
     "classnames": "^2.3.1",
-    "datocms-plugin-sdk": "^2.2.0-alpha.0",
+    "datocms-plugin-sdk": "^2.2.0-alpha.1",
     "react-intersection-observer": "^8.31.0",
     "react-select": "^5.2.1",
     "scroll-into-view-if-needed": "^2.2.20"
@@ -58,5 +58,5 @@
     "postcss-nested": "^5.0.6",
     "typedoc": "^0.26.7"
   },
-  "gitHead": "a523642c7188862c8431027e51ab479945dde5dd"
+  "gitHead": "6b88a998f0807c7da1e17afa6a8f0336aed7497f"
 }

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-react-ui",
-  "version": "2.2.0-alpha.1",
+  "version": "2.2.0-alpha.2",
   "description": "React components to use inside DatoCMS plugins",
   "keywords": [
     "datocms",
@@ -42,7 +42,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.27.16",
     "classnames": "^2.3.1",
-    "datocms-plugin-sdk": "^2.2.0-alpha.1",
+    "datocms-plugin-sdk": "^2.2.0-alpha.2",
     "react-intersection-observer": "^8.31.0",
     "react-select": "^5.2.1",
     "scroll-into-view-if-needed": "^2.2.20"

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-react-ui",
-  "version": "2.1.4",
+  "version": "3.0.0-alpha.0",
   "description": "React components to use inside DatoCMS plugins",
   "keywords": [
     "datocms",
@@ -42,7 +42,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.27.16",
     "classnames": "^2.3.1",
-    "datocms-plugin-sdk": "^2.1.1",
+    "datocms-plugin-sdk": "^3.0.0-alpha.0",
     "react-intersection-observer": "^8.31.0",
     "react-select": "^5.2.1",
     "scroll-into-view-if-needed": "^2.2.20"

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-react-ui",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.1-alpha.0",
   "description": "React components to use inside DatoCMS plugins",
   "keywords": [
     "datocms",
@@ -42,7 +42,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.27.16",
     "classnames": "^2.3.1",
-    "datocms-plugin-sdk": "^3.0.0-alpha.0",
+    "datocms-plugin-sdk": "^3.0.1-alpha.0",
     "react-intersection-observer": "^8.31.0",
     "react-select": "^5.2.1",
     "scroll-into-view-if-needed": "^2.2.20"

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-react-ui",
-  "version": "2.2.0-alpha.2",
+  "version": "2.2.0-alpha.3",
   "description": "React components to use inside DatoCMS plugins",
   "keywords": [
     "datocms",
@@ -42,7 +42,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.27.16",
     "classnames": "^2.3.1",
-    "datocms-plugin-sdk": "^2.2.0-alpha.2",
+    "datocms-plugin-sdk": "^2.2.0-alpha.3",
     "react-intersection-observer": "^8.31.0",
     "react-select": "^5.2.1",
     "scroll-into-view-if-needed": "^2.2.20"

--- a/packages/react-ui/src/Button/styles.module.css
+++ b/packages/react-ui/src/Button/styles.module.css
@@ -32,8 +32,8 @@
 }
 
 .buttonType-muted {
-  background-color: var(--color--tinted--surface);
-  color: var(--color--tinted--ink);
+  background-color: var(--color--primary-soft--surface);
+  color: var(--color--primary-soft--ink);
 
   &.disabled {
     background-color: var(--color--disabled--surface);
@@ -137,7 +137,7 @@
   line-height: 0.6;
 
   svg {
-    fill: var(--color--ink-accent);
+    fill: var(--color--ink-link);
   }
 }
 

--- a/packages/react-ui/src/Button/styles.module.css
+++ b/packages/react-ui/src/Button/styles.module.css
@@ -7,7 +7,7 @@
   cursor: pointer;
   line-height: inherit;
   background-color: transparent;
-  color: var(--base-body-color);
+  color: var(--color--ink);
   -webkit-appearance: none;
   -moz-appearance: none;
   border-radius: 4px;
@@ -32,56 +32,56 @@
 }
 
 .buttonType-muted {
-  background-color: var(--light-color);
-  color: var(--accent-color);
+  background-color: var(--color--tinted--surface);
+  color: var(--color--tinted--ink);
 
   &.disabled {
-    background-color: var(--light-bg-color);
-    color: rgba(0, 0, 0, 0.2);
+    background-color: var(--color--disabled--surface);
+    color: var(--color--disabled--ink);
 
     &:hover,
     &:focus,
     &:active {
-      color: rgba(0, 0, 0, 0.2);
+      color: var(--color--disabled--ink);
     }
   }
 }
 
 .buttonType-primary {
-  background-color: var(--accent-color);
-  color: white;
+  background-color: var(--color--primary--surface);
+  color: var(--color--primary--ink);
 
   &:hover,
   &:focus,
   &:active {
-    color: white;
+    color: var(--color--primary--ink);
   }
 
   &.disabled {
-    background-color: var(--disabled-bg-color);
-    color: rgba(0, 0, 0, 0.2);
+    background-color: var(--color--disabled--surface);
+    color: var(--color--disabled--ink);
     &:hover,
     &:focus,
     &:active {
-      color: rgba(0, 0, 0, 0.2);
+      color: var(--color--disabled--ink);
     }
   }
 }
 
 .buttonType-negative {
-  background-color: var(--alert-color);
-  color: white;
+  background-color: var(--color--danger--surface);
+  color: var(--color--danger--ink);
 
   &:hover,
   &:focus,
   &:active {
-    color: white;
-    background-color: var(--alert-color);
+    color: var(--color--danger--ink);
+    background-color: var(--color--danger--surface);
   }
 
   &.disabled {
-    background-color: var(--disabled-bg-color);
-    color: rgba(0, 0, 0, 0.2);
+    background-color: var(--color--disabled--surface);
+    color: var(--color--disabled--ink);
   }
 }
 
@@ -128,7 +128,7 @@
   line-height: 0.6;
 
   svg {
-    fill: var(--accent-color);
+    fill: var(--color--ink-accent);
   }
 }
 

--- a/packages/react-ui/src/Button/styles.module.css
+++ b/packages/react-ui/src/Button/styles.module.css
@@ -7,7 +7,7 @@
   cursor: pointer;
   line-height: inherit;
   background-color: transparent;
-  color: var(--base-body-color);
+  color: var(--color--ink);
   -webkit-appearance: none;
   -moz-appearance: none;
   border-radius: 4px;
@@ -32,56 +32,65 @@
 }
 
 .buttonType-muted {
-  background-color: var(--light-color);
-  color: var(--accent-color);
+  background-color: var(--color--tinted--surface);
+  color: var(--color--tinted--ink);
 
   &.disabled {
-    background-color: var(--light-bg-color);
-    color: rgba(0, 0, 0, 0.2);
+    background-color: var(--color--disabled--surface);
+    color: var(--color--disabled--ink);
 
     &:hover,
     &:focus,
     &:active {
-      color: rgba(0, 0, 0, 0.2);
+      color: var(--color--disabled--ink);
     }
   }
 }
 
 .buttonType-primary {
-  background-color: var(--accent-color);
-  color: white;
+  background-color: var(--color--primary--surface);
+  color: var(--color--primary--ink);
 
   &:hover,
   &:focus,
   &:active {
-    color: white;
+    color: var(--color--primary--ink);
+  }
+
+  &:hover {
+    background-color: var(--color--primary--surface-hover);
+  }
+
+  &:active,
+  &:focus {
+    background-color: var(--color--primary--surface-active);
   }
 
   &.disabled {
-    background-color: var(--disabled-bg-color);
-    color: rgba(0, 0, 0, 0.2);
+    background-color: var(--color--disabled--surface);
+    color: var(--color--disabled--ink);
     &:hover,
     &:focus,
     &:active {
-      color: rgba(0, 0, 0, 0.2);
+      color: var(--color--disabled--ink);
     }
   }
 }
 
 .buttonType-negative {
-  background-color: var(--alert-color);
-  color: white;
+  background-color: var(--color--danger--surface);
+  color: var(--color--danger--ink);
 
   &:hover,
   &:focus,
   &:active {
-    color: white;
-    background-color: var(--alert-color);
+    color: var(--color--danger--ink);
+    background-color: var(--color--danger--surface);
   }
 
   &.disabled {
-    background-color: var(--disabled-bg-color);
-    color: rgba(0, 0, 0, 0.2);
+    background-color: var(--color--disabled--surface);
+    color: var(--color--disabled--ink);
   }
 }
 
@@ -128,7 +137,7 @@
   line-height: 0.6;
 
   svg {
-    fill: var(--accent-color);
+    fill: var(--color--ink-accent);
   }
 }
 

--- a/packages/react-ui/src/ButtonGroup/Button/styles.module.css
+++ b/packages/react-ui/src/ButtonGroup/Button/styles.module.css
@@ -2,8 +2,8 @@
   font-family: inherit;
   cursor: pointer;
   line-height: inherit;
-  background-color: white;
-  color: var(--base-body-color);
+  background-color: var(--color--surface);
+  color: var(--color--ink);
   -webkit-appearance: none;
   -moz-appearance: none;
   font-size: inherit;
@@ -11,22 +11,20 @@
   border: 0;
   padding: 0;
   padding: 7px 13px;
-  border-right: 1px solid var(--border-color);
-  border: 1px solid var(--border-color);
-  border-left-width: 0;
+  border: 1px solid var(--color--border);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-column: center;
-  color: rgba(var(--base-body-color-rgb-components, 0.6));
+  color: var(--color--ink-subtle);
 }
 
 .Button:hover {
-  background-color: var(--light-bg-color);
+  background-color: var(--color--surface-hover);
 }
 
 .Button svg {
-  fill: var(--light-body-color);
+  fill: var(--color--ink-subtle);
 }
 
 .Button--s {
@@ -35,31 +33,31 @@
 
 .Button--disabled {
   cursor: not-allowed;
-  color: var(--light-body-color);
+  color: var(--color--disabled--ink);
 }
 
 .Button--disabled:hover {
-  background: white;
+  background: var(--color--surface);
 }
 
 .Button--selected {
-  background-color: var(--accent-color);
-  border-color: var(--accent-color);
-  color: white;
+  background-color: var(--color--accent--surface);
+  border-color: var(--color--selected--border);
+  color: var(--color--accent--ink);
 }
 
 .Button--selected svg {
-  fill: white;
+  fill: var(--color--accent--ink);
 }
 
 .Button--selected:hover {
-  background-color: var(--accent-color);
+  background-color: var(--color--accent--surface);
 }
 
 .Button--selected:hover,
 .Button--selected.Button--disabled {
-  background-color: rgba(var(--accent-color-rgb-components), 0.8);
-  border-color: rgba(var(--accent-color-rgb-components), 0.8);
+  background-color: var(--color--accent--surface);
+  border-color: var(--color--selected--border);
 }
 
 .Button:first-child {

--- a/packages/react-ui/src/ButtonGroup/Button/styles.module.css
+++ b/packages/react-ui/src/ButtonGroup/Button/styles.module.css
@@ -41,21 +41,21 @@
 }
 
 .Button--selected {
-  background-color: var(--color--accent--surface);
-  color: var(--color--accent--ink);
+  background-color: var(--color--primary--surface-secondary);
+  color: var(--color--primary--ink);
 }
 
 .Button--selected svg {
-  fill: var(--color--accent--ink);
+  fill: var(--color--primary--ink);
 }
 
 .Button--selected:hover {
-  background-color: var(--color--accent--surface);
+  background-color: var(--color--primary--surface-secondary);
 }
 
 .Button--selected:hover,
 .Button--selected.Button--disabled {
-  background-color: var(--color--accent--surface);
+  background-color: var(--color--primary--surface-secondary);
 }
 
 .Button:first-child {

--- a/packages/react-ui/src/ButtonGroup/Button/styles.module.css
+++ b/packages/react-ui/src/ButtonGroup/Button/styles.module.css
@@ -2,8 +2,8 @@
   font-family: inherit;
   cursor: pointer;
   line-height: inherit;
-  background-color: white;
-  color: var(--base-body-color);
+  background-color: var(--color--surface);
+  color: var(--color--ink);
   -webkit-appearance: none;
   -moz-appearance: none;
   font-size: inherit;
@@ -11,22 +11,20 @@
   border: 0;
   padding: 0;
   padding: 7px 13px;
-  border-right: 1px solid var(--border-color);
-  border: 1px solid var(--border-color);
-  border-left-width: 0;
+  border: 1px solid var(--color--border);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-column: center;
-  color: rgba(var(--base-body-color-rgb-components, 0.6));
+  color: var(--color--ink-subtle);
 }
 
 .Button:hover {
-  background-color: var(--light-bg-color);
+  background-color: var(--color--surface-hover);
 }
 
 .Button svg {
-  fill: var(--light-body-color);
+  fill: var(--color--ink-subtle);
 }
 
 .Button--s {
@@ -35,31 +33,29 @@
 
 .Button--disabled {
   cursor: not-allowed;
-  color: var(--light-body-color);
+  color: var(--color--disabled--ink);
 }
 
 .Button--disabled:hover {
-  background: white;
+  background: var(--color--surface);
 }
 
 .Button--selected {
-  background-color: var(--accent-color);
-  border-color: var(--accent-color);
-  color: white;
+  background-color: var(--color--accent--surface);
+  color: var(--color--accent--ink);
 }
 
 .Button--selected svg {
-  fill: white;
+  fill: var(--color--accent--ink);
 }
 
 .Button--selected:hover {
-  background-color: var(--accent-color);
+  background-color: var(--color--accent--surface);
 }
 
 .Button--selected:hover,
 .Button--selected.Button--disabled {
-  background-color: rgba(var(--accent-color-rgb-components), 0.8);
-  border-color: rgba(var(--accent-color-rgb-components), 0.8);
+  background-color: var(--color--accent--surface);
 }
 
 .Button:first-child {

--- a/packages/react-ui/src/ButtonGroup/Group/styles.module.css
+++ b/packages/react-ui/src/ButtonGroup/Group/styles.module.css
@@ -1,6 +1,6 @@
 .Group {
   display: flex;
   align-items: stretch;
-  background-color: white;
+  background-color: var(--color--surface);
   overflow: hidden;
 }

--- a/packages/react-ui/src/Canvas/index.tsx
+++ b/packages/react-ui/src/Canvas/index.tsx
@@ -63,11 +63,11 @@ export type CanvasProps = {
  *
  * **Context tokens** describe a self-contained mini-environment (a primary CTA, a danger button). Contexts come in two shapes:
  *
- * 1. **Ink-owning contexts**: signal contexts (primary, danger, accent, tinted, selected, feedback) and dark/inverted elevation contexts (overlay, backdrop, stacked, tooltip, code). Each defines an ink balanced on its own surface, so always pair surface and ink from the *same* context.
- * 2. **Single-property contexts**: focus (outline/border), progress (fill/track), highlight (surface), scrollbar (fill). Not surface+ink environments; the pairing rule doesn't apply.
+ * 1.  **Ink-owning contexts**: signal contexts (primary, primary-soft, danger, danger-soft, warning-soft, success-soft, selected) and dark/inverted elevation contexts (overlay, backdrop, stacked, tooltip, code). Each defines an ink balanced on its own surface, so always pair surface and ink from the *same* context.
+ * 2.  **Single-property contexts**: focus (outline/border), progress (fill/track), highlight (surface), scrollbar (fill). Not surface+ink environments; the pairing rule doesn't apply.
  *
  * > [!WARNING] Never cross ink-owning contexts
- * > Don't put a primary ink on a danger surface, or an accent surface under a tinted ink. Each ink-owning context is contrast-balanced as a unit, and mixing produces illegible combinations, especially in dark mode.
+ * > Don't put a primary ink on a danger surface, or a danger-soft surface under a warning-soft ink. Each ink-owning context is contrast-balanced as a unit, and mixing produces illegible combinations, especially in dark mode.
  *
  * #### Defining custom colors
  *
@@ -209,10 +209,9 @@ export type CanvasProps = {
  *           <p>
  *             The flat, low-contrast pair applied to non-interactive controls: disabled buttons, disabled selects and disabled toggles.
  *           </p>
- *           <Swatches
+ *           <PairSwatches
  *             tokens={[
- *               ['--color--disabled--surface', 'Background of a disabled button or control'],
- *               ['--color--disabled--ink', 'Label and icon color on a disabled control'],
+ *               ['--color--disabled--surface', '--color--disabled--ink', 'Disabled button or control: muted background with low-contrast label'],
  *             ]}
  *           />
  *         </Section>
@@ -228,10 +227,9 @@ export type CanvasProps = {
  *           <p>
  *             Reserved for destructive actions, such as Delete, Remove or Reset operations.
  *           </p>
- *           <Swatches
+ *           <PairSwatches
  *             tokens={[
- *               ['--color--danger--surface', 'Background of destructive action buttons like Delete'],
- *               ['--color--danger--ink', 'Text and icon color on a danger surface'],
+ *               ['--color--danger--surface', '--color--danger--ink', 'Destructive action button: vivid red surface with white label'],
  *             ]}
  *           />
  *         </Section>
@@ -341,7 +339,6 @@ export type CanvasProps = {
  *             Publishing-workflow status dots. Ink-only because the colored dot is the whole marker, no surface or border needed.
  *           </p>
  *           <Swatches
- *             kind="text"
  *             tokens={[
  *               ['--color--status-draft--ink', 'Dot color for records that exist only as a draft'],
  *               ['--color--status-outdated--ink', 'Dot color for published records with unpublished changes'],
@@ -361,10 +358,13 @@ export type CanvasProps = {
  *           <p>
  *             Two scrims for two jobs. The backdrop is the full-screen dim painted behind a modal dialog. The overlay is the lighter scrim that sits on top of media or thumbnails and hosts reversed buttons designed to read against dark imagery.
  *           </p>
+ *           <PairSwatches
+ *             tokens={[
+ *               ['--color--backdrop--surface', '--color--backdrop--ink', 'Full-screen modal dim with icon color for close controls'],
+ *             ]}
+ *           />
  *           <Swatches
  *             tokens={[
- *               ['--color--backdrop--surface', 'Full-screen dim behind modals and dialogs'],
- *               ['--color--backdrop--ink', 'Icon color for controls drawn directly on the backdrop, e.g. a modal close button'],
  *               ['--color--overlay--surface', 'Scrim painted over media thumbnails and image cards'],
  *               ['--color--overlay--surface-hover', 'Hover background of a reversed button floating on dark media'],
  *               ['--color--overlay--surface-active', 'Pressed background of a reversed button on dark media'],
@@ -450,10 +450,9 @@ export type CanvasProps = {
  *           <p>
  *             The dark monospaced surface used by build logs, error traces and other terminal-style output.
  *           </p>
- *           <Swatches
+ *           <PairSwatches
  *             tokens={[
- *               ['--color--code--surface', 'Background of code blocks, log panes and error traces'],
- *               ['--color--code--ink', 'Monospaced text color rendered on a code surface'],
+ *               ['--color--code--surface', '--color--code--ink', 'Dark monospaced surface with its text color'],
  *             ]}
  *           />
  *         </Section>
@@ -487,30 +486,19 @@ export type CanvasProps = {
  *           <p>
  *             Fixed-hue soft chips for field type group icons. Each context exposes a <code>surface</code> (chip background) and an <code>ink</code> (icon fill). The hues are not brand-adaptive — they are fixed across projects and automatically flip between a pale surface with saturated ink in light mode and a deep surface with bright ink in dark mode.
  *           </p>
- *           <Swatches
+ *           <PairSwatches
  *             tokens={[
- *               ['--color--field-group-text--surface', 'Chip background for text/string/structured-text fields'],
- *               ['--color--field-group-text--ink', 'Icon fill for text/string/structured-text fields'],
- *               ['--color--field-group-rich-text--surface', 'Chip background for rich-text and single-block fields'],
- *               ['--color--field-group-rich-text--ink', 'Icon fill for rich-text and single-block fields'],
- *               ['--color--field-group-media--surface', 'Chip background for file, gallery and video fields'],
- *               ['--color--field-group-media--ink', 'Icon fill for file, gallery and video fields'],
- *               ['--color--field-group-datetime--surface', 'Chip background for date and date-time fields'],
- *               ['--color--field-group-datetime--ink', 'Icon fill for date and date-time fields'],
- *               ['--color--field-group-number--surface', 'Chip background for integer and float fields'],
- *               ['--color--field-group-number--ink', 'Icon fill for integer and float fields'],
- *               ['--color--field-group-boolean--surface', 'Chip background for boolean fields'],
- *               ['--color--field-group-boolean--ink', 'Icon fill for boolean fields'],
- *               ['--color--field-group-location--surface', 'Chip background for lat/lon fields'],
- *               ['--color--field-group-location--ink', 'Icon fill for lat/lon fields'],
- *               ['--color--field-group-color--surface', 'Chip background for color fields'],
- *               ['--color--field-group-color--ink', 'Icon fill for color fields'],
- *               ['--color--field-group-seo--surface', 'Chip background for slug and SEO fields'],
- *               ['--color--field-group-seo--ink', 'Icon fill for slug and SEO fields'],
- *               ['--color--field-group-reference--surface', 'Chip background for link and links fields'],
- *               ['--color--field-group-reference--ink', 'Icon fill for link and links fields'],
- *               ['--color--field-group-json--surface', 'Chip background for JSON fields'],
- *               ['--color--field-group-json--ink', 'Icon fill for JSON fields'],
+ *               ['--color--field-group-text--surface', '--color--field-group-text--ink', 'Text / string / structured-text fields'],
+ *               ['--color--field-group-rich-text--surface', '--color--field-group-rich-text--ink', 'Rich-text and single-block fields'],
+ *               ['--color--field-group-media--surface', '--color--field-group-media--ink', 'File, gallery and video fields'],
+ *               ['--color--field-group-datetime--surface', '--color--field-group-datetime--ink', 'Date and date-time fields'],
+ *               ['--color--field-group-number--surface', '--color--field-group-number--ink', 'Integer and float fields'],
+ *               ['--color--field-group-boolean--surface', '--color--field-group-boolean--ink', 'Boolean fields'],
+ *               ['--color--field-group-location--surface', '--color--field-group-location--ink', 'Lat/lon fields'],
+ *               ['--color--field-group-color--surface', '--color--field-group-color--ink', 'Color fields'],
+ *               ['--color--field-group-seo--surface', '--color--field-group-seo--ink', 'Slug and SEO fields'],
+ *               ['--color--field-group-reference--surface', '--color--field-group-reference--ink', 'Link and links fields'],
+ *               ['--color--field-group-json--surface', '--color--field-group-json--ink', 'JSON fields'],
  *             ]}
  *           />
  *         </Section>
@@ -599,7 +587,7 @@ export function Canvas({
   // itself (`html`/`body`, outside the wrapper) can't reference them. Mirror
   // the scrollbar token onto the document root so the page-level scrollbar can
   // be themed too (consumed by the layered `html` rule in `base.css`).
-  const scrollbarFill = ctx.semanticColorTokensTheme['--color--scrollbar--fill'];
+  const scrollbarFill = ctx.cssDesignTokens['--color--scrollbar--fill'];
 
   useEffect(() => {
     if (typeof document === 'undefined' || !scrollbarFill) {

--- a/packages/react-ui/src/Canvas/index.tsx
+++ b/packages/react-ui/src/Canvas/index.tsx
@@ -34,281 +34,84 @@ export type CanvasProps = {
 };
 
 /**
- * @example Color palette CSS variables
+ * @example Semantic color token CSS variables
  *
- * Within the `Canvas` component, a color palette is made available as a set of
+ * Within the `Canvas` component, semantic color tokens are made available as
  * CSS variables, allowing you to conform to the theme of the current
- * environment:
+ * environment (including dark mode):
  *
  * ```js
  * <Canvas ctx={ctx}>
- *   <Section title="Text colors">
+ *   <Section title="Standalone">
  *     <table>
  *       <tbody>
- *         <tr>
- *           <td>
- *             <code>--base-body-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--base-body-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--light-body-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--light-body-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--placeholder-body-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--placeholder-body-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
+ *         {[
+ *           '--color--surface',
+ *           '--color--surface-hover',
+ *           '--color--surface-muted',
+ *           '--color--ink',
+ *           '--color--ink-subtle',
+ *           '--color--ink-placeholder',
+ *           '--color--ink-accent',
+ *           '--color--border',
+ *           '--color--border-hover',
+ *         ].map((v) => (
+ *           <tr key={v}>
+ *             <td><code>{v}</code></td>
+ *             <td width="30%">
+ *               <div style={{ width: '30px', height: '30px', background: `var(${v})` }} />
+ *             </td>
+ *           </tr>
+ *         ))}
  *       </tbody>
  *     </table>
  *   </Section>
- *   <Section title="UI colors">
+ *   <Section title="Contexts">
  *     <table>
  *       <tbody>
- *         <tr>
- *           <td>
- *             <code>--light-bg-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--light-bg-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--lighter-bg-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--lighter-bg-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--disabled-bg-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--disabled-bg-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--border-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--border-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--darker-border-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--darker-border-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--alert-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--alert-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--warning-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--warning-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--notice-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--notice-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--warning-bg-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--warning-bg-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--add-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--add-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--remove-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--remove-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
+ *         {[
+ *           '--color--primary--surface',
+ *           '--color--primary--ink',
+ *           '--color--tinted--surface',
+ *           '--color--tinted--ink',
+ *           '--color--accent--surface',
+ *           '--color--accent--ink',
+ *           '--color--selected--surface',
+ *           '--color--danger--surface',
+ *           '--color--danger--ink',
+ *           '--color--disabled--surface',
+ *           '--color--disabled--ink',
+ *           '--color--focus--border',
+ *           '--color--focus--outline',
+ *         ].map((v) => (
+ *           <tr key={v}>
+ *             <td><code>{v}</code></td>
+ *             <td width="30%">
+ *               <div style={{ width: '30px', height: '30px', background: `var(${v})` }} />
+ *             </td>
+ *           </tr>
+ *         ))}
  *       </tbody>
  *     </table>
  *   </Section>
- *   <Section title="Project-specific colors">
+ *   <Section title="Feedback">
  *     <table>
  *       <tbody>
- *         <tr>
- *           <td>
- *             <code>--accent-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--accent-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--primary-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--primary-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--light-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--light-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--dark-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--dark-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
+ *         {[
+ *           '--color--feedback-fail--ink',
+ *           '--color--feedback-fail--border',
+ *           '--color--feedback-warning--ink',
+ *           '--color--feedback-warning--surface',
+ *           '--color--feedback-success--ink',
+ *           '--color--feedback-success--border',
+ *         ].map((v) => (
+ *           <tr key={v}>
+ *             <td><code>{v}</code></td>
+ *             <td width="30%">
+ *               <div style={{ width: '30px', height: '30px', background: `var(${v})` }} />
+ *             </td>
+ *           </tr>
+ *         ))}
  *       </tbody>
  *     </table>
  *   </Section>
@@ -443,7 +246,7 @@ export type CanvasProps = {
  *         <td>
  *           <div
  *             style={{
- *               background: 'var(--accent-color)',
+ *               background: 'var(--color--accent--surface)',
  *               width: 'var(--spacing-s)',
  *               height: 'var(--spacing-s)',
  *             }}
@@ -457,7 +260,7 @@ export type CanvasProps = {
  *         <td>
  *           <div
  *             style={{
- *               background: 'var(--accent-color)',
+ *               background: 'var(--color--accent--surface)',
  *               width: 'var(--spacing-m)',
  *               height: 'var(--spacing-m)',
  *             }}
@@ -471,7 +274,7 @@ export type CanvasProps = {
  *         <td>
  *           <div
  *             style={{
- *               background: 'var(--accent-color)',
+ *               background: 'var(--color--accent--surface)',
  *               width: 'var(--spacing-l)',
  *               height: 'var(--spacing-l)',
  *             }}
@@ -485,7 +288,7 @@ export type CanvasProps = {
  *         <td>
  *           <div
  *             style={{
- *               background: 'var(--accent-color)',
+ *               background: 'var(--color--accent--surface)',
  *               width: 'var(--spacing-xl)',
  *               height: 'var(--spacing-xl)',
  *             }}
@@ -499,7 +302,7 @@ export type CanvasProps = {
  *         <td>
  *           <div
  *             style={{
- *               background: 'var(--accent-color)',
+ *               background: 'var(--color--accent--surface)',
  *               width: 'var(--spacing-xxl)',
  *               height: 'var(--spacing-xxl)',
  *             }}
@@ -513,7 +316,7 @@ export type CanvasProps = {
  *         <td>
  *           <div
  *             style={{
- *               background: 'var(--accent-color)',
+ *               background: 'var(--color--accent--surface)',
  *               width: 'var(--spacing-xxxl)',
  *               height: 'var(--spacing-xxxl)',
  *             }}

--- a/packages/react-ui/src/Canvas/index.tsx
+++ b/packages/react-ui/src/Canvas/index.tsx
@@ -63,158 +63,347 @@ export type CanvasProps = {
  *
  * ```js
  * <Canvas ctx={ctx}>
- *   <Section title="Standalone — use on any neutral page">
- *     <table><tbody>
- *       {[
- *         ['--color--surface',          'Default page background'],
- *         ['--color--surface-hover',    'Hovered row / list item'],
- *         ['--color--surface-muted',    'Muted section / card background'],
- *         ['--color--ink',              'Primary text'],
- *         ['--color--ink-subtle',       'Secondary text / captions'],
- *         ['--color--ink-hover',        'Text under hover'],
- *         ['--color--ink-muted',        'De-emphasized text'],
- *         ['--color--ink-placeholder',  'Input placeholder text'],
- *         ['--color--ink-primary',      'Brand-highlighted text / icons'],
- *         ['--color--ink-accent',       'Links / accent text'],
- *         ['--color--ink-disabled',     'Disabled text'],
- *         ['--color--border',           'Default 1px border'],
- *         ['--color--border-hover',     'Border under hover'],
- *       ].map(([t, d]) => (
- *         <tr key={t}>
- *           <td><code>{t}</code></td>
- *           <td style={{ color: 'var(--color--ink-subtle)' }}>{d}</td>
- *           <td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td>
- *         </tr>
- *       ))}
- *     </tbody></table>
- *   </Section>
- *
- *   <Section title="Context: raised — modals, dropdowns, popovers">
- *     <table><tbody>
- *       {['--color--raised--surface', '--color--raised--surface-hover', '--color--raised--surface-active']
- *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
- *     </tbody></table>
- *   </Section>
- *
- *   <Section title="Context: primary — main call-to-action buttons, badges, nav">
- *     <table><tbody>
- *       {['--color--primary--surface', '--color--primary--surface-hover', '--color--primary--surface-active', '--color--primary--surface-muted', '--color--primary--ink', '--color--primary--border']
- *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
- *     </tbody></table>
- *   </Section>
- *
- *   <Section title="Context: tinted — subtle brand-tinted surfaces">
- *     <table><tbody>
- *       {['--color--tinted--surface', '--color--tinted--surface-hover', '--color--tinted--surface-active', '--color--tinted--ink', '--color--tinted--border']
- *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
- *     </tbody></table>
- *   </Section>
- *
- *   <Section title="Context: accent, selected, disabled, danger">
- *     <table><tbody>
- *       {['--color--accent--surface', '--color--accent--ink',
- *         '--color--selected--surface', '--color--selected--ink', '--color--selected--border',
- *         '--color--disabled--surface', '--color--disabled--ink',
- *         '--color--danger--surface', '--color--danger--ink']
- *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
- *     </tbody></table>
- *   </Section>
- *
- *   <Section title="Context: focus — focus rings and outlines">
- *     <table><tbody>
- *       {['--color--focus--border', '--color--focus--outline']
- *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
- *     </tbody></table>
- *   </Section>
- *
- *   <Section title="Feedback — validation and form states">
- *     <table><tbody>
- *       {['--color--feedback-fail--ink', '--color--feedback-fail--border', '--color--feedback-fail--outline', '--color--feedback-fail--surface',
- *         '--color--feedback-warning--ink', '--color--feedback-warning--border', '--color--feedback-warning--outline', '--color--feedback-warning--surface',
- *         '--color--feedback-success--ink', '--color--feedback-success--border', '--color--feedback-success--outline', '--color--feedback-success--surface']
- *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
- *     </tbody></table>
- *   </Section>
- *
- *   <Section title="Context: highlight — rich text inline highlights">
- *     <table><tbody>
- *       {['--color--highlight--surface']
- *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
- *     </tbody></table>
- *   </Section>
- *
- *   <Section title="Diffs — content versioning (added / removed / changed)">
- *     <table><tbody>
- *       {['--color--diff-added--surface', '--color--diff-added--outline', '--color--diff-added--ink', '--color--diff-added--ink-subtle',
- *         '--color--diff-removed--surface', '--color--diff-removed--outline', '--color--diff-removed--ink', '--color--diff-removed--ink-subtle',
- *         '--color--diff-changed--surface', '--color--diff-changed--outline']
- *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
- *     </tbody></table>
- *   </Section>
- *
- *   <Section title="Status — publishing workflow badges (ink-only)">
- *     <table><tbody>
- *       {['--color--status-draft--ink', '--color--status-outdated--ink', '--color--status-published--ink']
- *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td><span style={{ color: `var(${t})`, fontWeight: 'bold' }}>Sample text</span></td></tr>))}
- *     </tbody></table>
- *   </Section>
- *
- *   <Section title="Backdrop & overlay — scrims and floating UI">
- *     <table><tbody>
- *       {['--color--backdrop--surface', '--color--backdrop--ink',
- *         '--color--overlay--surface', '--color--overlay--surface-hover', '--color--overlay--surface-active', '--color--overlay--ink']
- *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
- *     </tbody></table>
- *   </Section>
- *
- *   <Section title="Stacked — dark layered UI (uploaders, media players)">
- *     <p>Stacked gives you layered dark surfaces (base → upper) plus action buttons, borders and ink tones. Use it when a dark inline panel needs internal hierarchy.</p>
- *     <table><tbody>
- *       {['--color--stacked--surface', '--color--stacked--surface-upper',
- *         '--color--stacked--surface-action', '--color--stacked--surface-action-hover', '--color--stacked--surface-action-active',
- *         '--color--stacked--ink', '--color--stacked--ink-subtle', '--color--stacked--border']
- *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
- *     </tbody></table>
- *   </Section>
- *
- *   <Section title="Progress — bar track and fill">
- *     <table><tbody>
- *       {['--color--progress--track', '--color--progress--fill', '--color--progress--fill-hover']
- *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
- *     </tbody></table>
- *   </Section>
- *
- *   <Section title="Tooltip — small dark floating labels">
- *     <table><tbody>
- *       {['--color--tooltip--surface', '--color--tooltip--surface-hover', '--color--tooltip--ink', '--color--tooltip--ink-subtle']
- *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
- *     </tbody></table>
- *   </Section>
- *
- *   <Section title="Code — dark code blocks, logs, error traces">
- *     <table><tbody>
- *       {['--color--code--surface', '--color--code--ink']
- *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
- *     </tbody></table>
- *   </Section>
- *
- *   <Section title="Scrollbar">
- *     <table><tbody>
- *       {['--color--scrollbar--fill']
- *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
- *     </tbody></table>
- *   </Section>
- *
- *   <Section title="Shadow composites — drop-in box-shadow values">
- *     <div style={{ display: 'flex', gap: 'var(--spacing-l)', padding: 'var(--spacing-l)' }}>
- *       {['--shadow--raised', '--shadow--floating', '--shadow--lifted', '--shadow--ambient'].map((t) => (
- *         <div key={t} style={{ textAlign: 'center' }}>
- *           <div style={{ width: '80px', height: '80px', background: 'var(--color--surface)', borderRadius: '4px', boxShadow: `var(${t})` }} />
- *           <code style={{ display: 'block', marginTop: 'var(--spacing-s)', fontSize: 'var(--font-size-xs)' }}>{t}</code>
- *         </div>
- *       ))}
- *     </div>
- *   </Section>
+ *   <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-l)' }}>
+ *     <StateManager initial={true}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Standalone — use on any neutral page"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches
+ *             tokens={[
+ *               ['--color--surface', 'Default page background'],
+ *               ['--color--surface-hover', 'Hovered row / list item'],
+ *               ['--color--surface-muted', 'Muted section / card background'],
+ *               ['--color--ink', 'Primary text'],
+ *               ['--color--ink-subtle', 'Secondary text / captions'],
+ *               ['--color--ink-hover', 'Text under hover'],
+ *               ['--color--ink-muted', 'De-emphasized text'],
+ *               ['--color--ink-placeholder', 'Input placeholder text'],
+ *               ['--color--ink-primary', 'Brand-highlighted text / icons'],
+ *               ['--color--ink-accent', 'Links / accent text'],
+ *               ['--color--ink-disabled', 'Disabled text'],
+ *               ['--color--border', 'Default 1px border'],
+ *               ['--color--border-hover', 'Border under hover'],
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Context: raised — modals, dropdowns, popovers"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches
+ *             tokens={[
+ *               '--color--surface-raised',
+ *               '--color--surface-raised-hover',
+ *               '--color--surface-raised-active',
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Context: primary — main call-to-action buttons, badges, nav"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches
+ *             tokens={[
+ *               '--color--primary--surface',
+ *               '--color--primary--surface-hover',
+ *               '--color--primary--surface-active',
+ *               '--color--primary--surface-muted',
+ *               '--color--primary--ink',
+ *               '--color--primary--border',
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Context: tinted — subtle brand-tinted surfaces"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches
+ *             tokens={[
+ *               '--color--tinted--surface',
+ *               '--color--tinted--surface-hover',
+ *               '--color--tinted--surface-active',
+ *               '--color--tinted--ink',
+ *               '--color--tinted--border',
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Context: accent — emphasized non-primary surfaces"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches tokens={['--color--accent--surface', '--color--accent--ink']} />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Context: selected — active selection state"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches
+ *             tokens={[
+ *               '--color--selected--surface',
+ *               '--color--selected--ink',
+ *               '--color--selected--border',
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Context: disabled — inactive controls"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches tokens={['--color--disabled--surface', '--color--disabled--ink']} />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Context: danger — destructive actions"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches tokens={['--color--danger--surface', '--color--danger--ink']} />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Context: focus — focus rings and outlines"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches tokens={['--color--focus--border', '--color--focus--outline']} />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Feedback — validation and form states"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches
+ *             tokens={[
+ *               '--color--feedback-fail--ink',
+ *               '--color--feedback-fail--border',
+ *               '--color--feedback-fail--outline',
+ *               '--color--feedback-fail--surface',
+ *               '--color--feedback-warning--ink',
+ *               '--color--feedback-warning--border',
+ *               '--color--feedback-warning--outline',
+ *               '--color--feedback-warning--surface',
+ *               '--color--feedback-success--ink',
+ *               '--color--feedback-success--border',
+ *               '--color--feedback-success--outline',
+ *               '--color--feedback-success--surface',
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Context: highlight — rich text inline highlights"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches tokens={['--color--highlight--surface']} />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Diffs — content versioning (added / removed / changed)"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches
+ *             tokens={[
+ *               '--color--diff-added--surface',
+ *               '--color--diff-added--outline',
+ *               '--color--diff-added--ink',
+ *               '--color--diff-added--ink-subtle',
+ *               '--color--diff-removed--surface',
+ *               '--color--diff-removed--outline',
+ *               '--color--diff-removed--ink',
+ *               '--color--diff-removed--ink-subtle',
+ *               '--color--diff-changed--surface',
+ *               '--color--diff-changed--outline',
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Status — publishing workflow badges (ink-only)"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches
+ *             kind="text"
+ *             tokens={[
+ *               '--color--status-draft--ink',
+ *               '--color--status-outdated--ink',
+ *               '--color--status-published--ink',
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Backdrop & overlay — scrims and floating UI"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches
+ *             tokens={[
+ *               '--color--backdrop--surface',
+ *               '--color--backdrop--ink',
+ *               '--color--overlay--surface',
+ *               '--color--overlay--surface-hover',
+ *               '--color--overlay--surface-active',
+ *               '--color--overlay--ink',
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Stacked — dark layered UI (uploaders, media players)"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <p>
+ *             Stacked gives you layered dark surfaces (base → upper) plus action buttons, borders and
+ *             ink tones. Use it when a dark inline panel needs internal hierarchy.
+ *           </p>
+ *           <Swatches
+ *             tokens={[
+ *               '--color--stacked--surface',
+ *               '--color--stacked--surface-upper',
+ *               '--color--stacked--surface-action',
+ *               '--color--stacked--surface-action-hover',
+ *               '--color--stacked--surface-action-active',
+ *               '--color--stacked--ink',
+ *               '--color--stacked--ink-subtle',
+ *               '--color--stacked--border',
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Progress — bar track and fill"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches
+ *             tokens={[
+ *               '--color--progress--track',
+ *               '--color--progress--fill',
+ *               '--color--progress--fill-hover',
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Tooltip — small dark floating labels"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches
+ *             tokens={[
+ *               '--color--tooltip--surface',
+ *               '--color--tooltip--surface-hover',
+ *               '--color--tooltip--ink',
+ *               '--color--tooltip--ink-subtle',
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Code — dark code blocks, logs, error traces"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches tokens={['--color--code--surface', '--color--code--ink']} />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Scrollbar"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches tokens={['--color--scrollbar--fill']} />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Shadow composites — drop-in box-shadow values"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <Swatches
+ *             kind="shadow"
+ *             tokens={['--shadow--raised', '--shadow--floating', '--shadow--lifted', '--shadow--ambient']}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *   </div>
  * </Canvas>;
  * ```
  *

--- a/packages/react-ui/src/Canvas/index.tsx
+++ b/packages/react-ui/src/Canvas/index.tsx
@@ -638,6 +638,31 @@ export function Canvas({
     return undefined;
   }, [mode, noAutoResizer]);
 
+  // The semantic color tokens are only set on the canvas wrapper, so the page
+  // itself (`html`/`body`, outside the wrapper) can't reference them. Mirror
+  // the scrollbar token onto the document root so the page-level scrollbar can
+  // be themed too (consumed by the layered `html` rule in `base.css`).
+  const scrollbarFill = ctx.semanticColorTokensTheme['--color--scrollbar--fill'];
+
+  useEffect(() => {
+    if (typeof document === 'undefined' || !scrollbarFill) {
+      return undefined;
+    }
+
+    const property = '--color--scrollbar--fill';
+    const root = document.documentElement;
+    const previous = root.style.getPropertyValue(property);
+    root.style.setProperty(property, scrollbarFill);
+
+    return () => {
+      if (previous) {
+        root.style.setProperty(property, previous);
+      } else {
+        root.style.removeProperty(property);
+      }
+    };
+  }, [scrollbarFill]);
+
   return (
     <CtxContext.Provider value={ctx}>
       <div

--- a/packages/react-ui/src/Canvas/index.tsx
+++ b/packages/react-ui/src/Canvas/index.tsx
@@ -477,6 +477,45 @@ export type CanvasProps = {
  *         </Section>
  *       )}
  *     </StateManager>
+ *
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Field type groups"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <p>
+ *             Fixed-hue soft chips for field type group icons. Each context exposes a <code>surface</code> (chip background) and an <code>ink</code> (icon fill). The hues are not brand-adaptive — they are fixed across projects and automatically flip between a pale surface with saturated ink in light mode and a deep surface with bright ink in dark mode.
+ *           </p>
+ *           <Swatches
+ *             tokens={[
+ *               ['--color--field-group-text--surface', 'Chip background for text/string/structured-text fields'],
+ *               ['--color--field-group-text--ink', 'Icon fill for text/string/structured-text fields'],
+ *               ['--color--field-group-rich-text--surface', 'Chip background for rich-text and single-block fields'],
+ *               ['--color--field-group-rich-text--ink', 'Icon fill for rich-text and single-block fields'],
+ *               ['--color--field-group-media--surface', 'Chip background for file, gallery and video fields'],
+ *               ['--color--field-group-media--ink', 'Icon fill for file, gallery and video fields'],
+ *               ['--color--field-group-datetime--surface', 'Chip background for date and date-time fields'],
+ *               ['--color--field-group-datetime--ink', 'Icon fill for date and date-time fields'],
+ *               ['--color--field-group-number--surface', 'Chip background for integer and float fields'],
+ *               ['--color--field-group-number--ink', 'Icon fill for integer and float fields'],
+ *               ['--color--field-group-boolean--surface', 'Chip background for boolean fields'],
+ *               ['--color--field-group-boolean--ink', 'Icon fill for boolean fields'],
+ *               ['--color--field-group-location--surface', 'Chip background for lat/lon fields'],
+ *               ['--color--field-group-location--ink', 'Icon fill for lat/lon fields'],
+ *               ['--color--field-group-color--surface', 'Chip background for color fields'],
+ *               ['--color--field-group-color--ink', 'Icon fill for color fields'],
+ *               ['--color--field-group-seo--surface', 'Chip background for slug and SEO fields'],
+ *               ['--color--field-group-seo--ink', 'Icon fill for slug and SEO fields'],
+ *               ['--color--field-group-reference--surface', 'Chip background for link and links fields'],
+ *               ['--color--field-group-reference--ink', 'Icon fill for link and links fields'],
+ *               ['--color--field-group-json--surface', 'Chip background for JSON fields'],
+ *               ['--color--field-group-json--ink', 'Icon fill for JSON fields'],
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
  *   </div>
  * </Canvas>;
  * ```

--- a/packages/react-ui/src/Canvas/index.tsx
+++ b/packages/react-ui/src/Canvas/index.tsx
@@ -34,32 +34,65 @@ export type CanvasProps = {
 };
 
 /**
- * @example Semantic color token CSS variables
+ * @example Colors
  *
- * Inside `Canvas`, the host exposes a full semantic color palette as CSS
- * custom properties. Components should reference these tokens directly —
- * they adapt to the user's active theme (including dark mode)
- * automatically.
+ * A full semantic color palette is exposed inside `Canvas` as `--color--*` CSS variables.
  *
- * ### How to read a token name
+ * Regarding dark mode, `ctx.colorScheme` resolves to `'light'` or `'dark'`. The SDK runtime also sets `data-color-scheme` on `<html>` so selectors like `[data-color-scheme="dark"] {…}` work out of the box.
  *
+ * #### Token name shape
+ *
+ * Tokens follow one of two name shapes:
+ *
+ * | Shape | Meaning |
+ * | --- | --- |
+ * | `--color--{property}` | standalone (one `--` after color) |
+ * | `--color--{context}--{property}` | context pair (two `--` after color) |
+ *
+ * **Properties** are the role a color plays:
+ *
+ * | Property | Role |
+ * | --- | --- |
+ * | `surface` | backgrounds |
+ * | `ink` | text and icons |
+ * | `border` | 1px lines |
+ * | `outline` | focus rings and block-level rings |
+ * | `fill` / `track` | indicator fills and their backgrounds |
+ *
+ * **Standalone tokens** are for neutral page chrome; use them by default. Elevated neutral surfaces (modals, dropdowns, popovers) are standalone too, with hover and active variants for the raised layer. Pair them with the standalone ink tokens.
+ *
+ * **Context tokens** describe a self-contained mini-environment (a primary CTA, a danger button). Contexts come in two shapes:
+ *
+ * 1. **Ink-owning contexts**: signal contexts (primary, danger, accent, tinted, selected, feedback) and dark/inverted elevation contexts (overlay, backdrop, stacked, tooltip, code). Each defines an ink balanced on its own surface, so always pair surface and ink from the *same* context.
+ * 2. **Single-property contexts**: focus (outline/border), progress (fill/track), highlight (surface), scrollbar (fill). Not surface+ink environments; the pairing rule doesn't apply.
+ *
+ * > [!WARNING] Never cross ink-owning contexts
+ * > Don't put a primary ink on a danger surface, or an accent surface under a tinted ink. Each ink-owning context is contrast-balanced as a unit, and mixing produces illegible combinations, especially in dark mode.
+ *
+ * #### Defining custom colors
+ *
+ * Reserve custom colors for things genuinely outside the design system, such as brand illustrations, data-viz palettes, vendor-specific UI. Most needs ("primary button color", "error state") are already covered by tokens. When a custom color is justified, define it once per theme using the `[data-color-scheme="dark"]` selector that the SDK already sets:
+ *
+ * ```css
+ * .my-plugin {
+ *   --my-brand: #4a90e2;
+ * }
+ *
+ * [data-color-scheme="dark"] .my-plugin {
+ *   --my-brand: #6aa9ec;
+ * }
+ *
+ * .my-plugin__cta {
+ *   background: var(--my-brand);
+ *   color: var(--color--primary--ink);
+ * }
  * ```
- * --color--{property}                 // standalone (one -- after color)
- * --color--{context}--{property}      // context pair (two -- after color)
- * ```
  *
- * **Properties** — `surface` (backgrounds), `ink` (text/icons),
- * `border` (1px lines), `outline` (focus rings), plus `fill` / `track`
- * for progress bars.
+ * For non-CSS branching (image sources, third-party widget themes, syntax-highlighting presets), branch on `ctx.colorScheme` directly, e.g. `<img src={ctx.colorScheme === 'dark' ? logoDark : logoLight} />`. On modern browsers, the CSS `light-dark()` function is a more concise alternative to the per-theme variable pattern above.
  *
- * **Standalone** tokens work on any neutral page. **Contexts** are
- * self-contained environments: always pair a `surface` with the `ink`,
- * `border`, and hover states from the *same* context. Never mix — e.g.
- * don't put `--color--primary--ink` on `--color--danger--surface`.
+ * #### Available tokens
  *
- * Non-color tokens `--shadow--raised` / `--shadow--floating` /
- * `--shadow--lifted` / `--shadow--ambient` are ready-made `box-shadow`
- * composites.
+ * A swatch for every available token, grouped by context.
  *
  * ```js
  * <Canvas ctx={ctx}>
@@ -67,338 +100,394 @@ export type CanvasProps = {
  *     <StateManager initial={true}>
  *       {(isOpen, setOpen) => (
  *         <Section
- *           title="Standalone — use on any neutral page"
- *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
- *         >
- *           <Swatches
- *             tokens={[
- *               ['--color--surface', 'Default page background'],
- *               ['--color--surface-hover', 'Hovered row / list item'],
- *               ['--color--surface-muted', 'Muted section / card background'],
- *               ['--color--ink', 'Primary text'],
- *               ['--color--ink-subtle', 'Secondary text / captions'],
- *               ['--color--ink-hover', 'Text under hover'],
- *               ['--color--ink-muted', 'De-emphasized text'],
- *               ['--color--ink-placeholder', 'Input placeholder text'],
- *               ['--color--ink-primary', 'Brand-highlighted text / icons'],
- *               ['--color--ink-accent', 'Links / accent text'],
- *               ['--color--ink-disabled', 'Disabled text'],
- *               ['--color--border', 'Default 1px border'],
- *               ['--color--border-hover', 'Border under hover'],
- *             ]}
- *           />
- *         </Section>
- *       )}
- *     </StateManager>
- *   
- *     <StateManager initial={false}>
- *       {(isOpen, setOpen) => (
- *         <Section
- *           title="Context: raised — modals, dropdowns, popovers"
- *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
- *         >
- *           <Swatches
- *             tokens={[
- *               '--color--surface-raised',
- *               '--color--surface-raised-hover',
- *               '--color--surface-raised-active',
- *             ]}
- *           />
- *         </Section>
- *       )}
- *     </StateManager>
- *   
- *     <StateManager initial={false}>
- *       {(isOpen, setOpen) => (
- *         <Section
- *           title="Context: primary — main call-to-action buttons, badges, nav"
- *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
- *         >
- *           <Swatches
- *             tokens={[
- *               '--color--primary--surface',
- *               '--color--primary--surface-hover',
- *               '--color--primary--surface-active',
- *               '--color--primary--surface-muted',
- *               '--color--primary--ink',
- *               '--color--primary--border',
- *             ]}
- *           />
- *         </Section>
- *       )}
- *     </StateManager>
- *   
- *     <StateManager initial={false}>
- *       {(isOpen, setOpen) => (
- *         <Section
- *           title="Context: tinted — subtle brand-tinted surfaces"
- *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
- *         >
- *           <Swatches
- *             tokens={[
- *               '--color--tinted--surface',
- *               '--color--tinted--surface-hover',
- *               '--color--tinted--surface-active',
- *               '--color--tinted--ink',
- *               '--color--tinted--border',
- *             ]}
- *           />
- *         </Section>
- *       )}
- *     </StateManager>
- *   
- *     <StateManager initial={false}>
- *       {(isOpen, setOpen) => (
- *         <Section
- *           title="Context: accent — emphasized non-primary surfaces"
- *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
- *         >
- *           <Swatches tokens={['--color--accent--surface', '--color--accent--ink']} />
- *         </Section>
- *       )}
- *     </StateManager>
- *   
- *     <StateManager initial={false}>
- *       {(isOpen, setOpen) => (
- *         <Section
- *           title="Context: selected — active selection state"
- *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
- *         >
- *           <Swatches
- *             tokens={[
- *               '--color--selected--surface',
- *               '--color--selected--ink',
- *               '--color--selected--border',
- *             ]}
- *           />
- *         </Section>
- *       )}
- *     </StateManager>
- *   
- *     <StateManager initial={false}>
- *       {(isOpen, setOpen) => (
- *         <Section
- *           title="Context: disabled — inactive controls"
- *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
- *         >
- *           <Swatches tokens={['--color--disabled--surface', '--color--disabled--ink']} />
- *         </Section>
- *       )}
- *     </StateManager>
- *   
- *     <StateManager initial={false}>
- *       {(isOpen, setOpen) => (
- *         <Section
- *           title="Context: danger — destructive actions"
- *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
- *         >
- *           <Swatches tokens={['--color--danger--surface', '--color--danger--ink']} />
- *         </Section>
- *       )}
- *     </StateManager>
- *   
- *     <StateManager initial={false}>
- *       {(isOpen, setOpen) => (
- *         <Section
- *           title="Context: focus — focus rings and outlines"
- *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
- *         >
- *           <Swatches tokens={['--color--focus--border', '--color--focus--outline']} />
- *         </Section>
- *       )}
- *     </StateManager>
- *   
- *     <StateManager initial={false}>
- *       {(isOpen, setOpen) => (
- *         <Section
- *           title="Feedback — validation and form states"
- *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
- *         >
- *           <Swatches
- *             tokens={[
- *               '--color--feedback-fail--ink',
- *               '--color--feedback-fail--border',
- *               '--color--feedback-fail--outline',
- *               '--color--feedback-fail--surface',
- *               '--color--feedback-warning--ink',
- *               '--color--feedback-warning--border',
- *               '--color--feedback-warning--outline',
- *               '--color--feedback-warning--surface',
- *               '--color--feedback-success--ink',
- *               '--color--feedback-success--border',
- *               '--color--feedback-success--outline',
- *               '--color--feedback-success--surface',
- *             ]}
- *           />
- *         </Section>
- *       )}
- *     </StateManager>
- *   
- *     <StateManager initial={false}>
- *       {(isOpen, setOpen) => (
- *         <Section
- *           title="Context: highlight — rich text inline highlights"
- *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
- *         >
- *           <Swatches tokens={['--color--highlight--surface']} />
- *         </Section>
- *       )}
- *     </StateManager>
- *   
- *     <StateManager initial={false}>
- *       {(isOpen, setOpen) => (
- *         <Section
- *           title="Diffs — content versioning (added / removed / changed)"
- *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
- *         >
- *           <Swatches
- *             tokens={[
- *               '--color--diff-added--surface',
- *               '--color--diff-added--outline',
- *               '--color--diff-added--ink',
- *               '--color--diff-added--ink-subtle',
- *               '--color--diff-removed--surface',
- *               '--color--diff-removed--outline',
- *               '--color--diff-removed--ink',
- *               '--color--diff-removed--ink-subtle',
- *               '--color--diff-changed--surface',
- *               '--color--diff-changed--outline',
- *             ]}
- *           />
- *         </Section>
- *       )}
- *     </StateManager>
- *   
- *     <StateManager initial={false}>
- *       {(isOpen, setOpen) => (
- *         <Section
- *           title="Status — publishing workflow badges (ink-only)"
- *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
- *         >
- *           <Swatches
- *             kind="text"
- *             tokens={[
- *               '--color--status-draft--ink',
- *               '--color--status-outdated--ink',
- *               '--color--status-published--ink',
- *             ]}
- *           />
- *         </Section>
- *       )}
- *     </StateManager>
- *   
- *     <StateManager initial={false}>
- *       {(isOpen, setOpen) => (
- *         <Section
- *           title="Backdrop & overlay — scrims and floating UI"
- *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
- *         >
- *           <Swatches
- *             tokens={[
- *               '--color--backdrop--surface',
- *               '--color--backdrop--ink',
- *               '--color--overlay--surface',
- *               '--color--overlay--surface-hover',
- *               '--color--overlay--surface-active',
- *               '--color--overlay--ink',
- *             ]}
- *           />
- *         </Section>
- *       )}
- *     </StateManager>
- *   
- *     <StateManager initial={false}>
- *       {(isOpen, setOpen) => (
- *         <Section
- *           title="Stacked — dark layered UI (uploaders, media players)"
+ *           title="Standalone"
  *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
  *         >
  *           <p>
- *             Stacked gives you layered dark surfaces (base → upper) plus action buttons, borders and
- *             ink tones. Use it when a dark inline panel needs internal hierarchy.
+ *             One-level tokens that work on any neutral page. The <code>surface</code>, <code>ink</code> and <code>border</code> families cover the page background, body text and dividers; the <code>surface-raised</code> variants belong to the elevated layer used by modals, dropdowns and popovers.
  *           </p>
  *           <Swatches
  *             tokens={[
- *               '--color--stacked--surface',
- *               '--color--stacked--surface-upper',
- *               '--color--stacked--surface-action',
- *               '--color--stacked--surface-action-hover',
- *               '--color--stacked--surface-action-active',
- *               '--color--stacked--ink',
- *               '--color--stacked--ink-subtle',
- *               '--color--stacked--border',
+ *               ['--color--surface', 'Page background everything else sits on'],
+ *               ['--color--surface-hover', 'Hovered row inside lists and tables'],
+ *               ['--color--surface-muted', 'Background of muted section panels and quiet cards'],
+ *               ['--color--surface-raised', 'Elevated layer for modals, dropdowns and popovers'],
+ *               ['--color--surface-raised-hover', 'Hovered option inside a dropdown menu'],
+ *               ['--color--surface-raised-active', 'Focused or pressed option inside a dropdown menu'],
+ *               ['--color--ink', 'Primary body text'],
+ *               ['--color--ink-subtle', 'Secondary text, captions, helper labels'],
+ *               ['--color--ink-hover', 'Toolbar icon and link fill on hover'],
+ *               ['--color--ink-muted', 'Deemphasized text that should recede'],
+ *               ['--color--ink-placeholder', 'Empty-input placeholder text'],
+ *               ['--color--ink-primary', 'Theme-colored text and icons for branded labels'],
+ *               ['--color--ink-accent', 'Inline links and accent text'],
+ *               ['--color--ink-disabled', 'Label color on disabled inputs and buttons'],
+ *               ['--color--border', 'Default 1px divider between cards, rows and sections'],
+ *               ['--color--border-hover', 'Border of an input or card when hovered'],
  *             ]}
  *           />
  *         </Section>
  *       )}
  *     </StateManager>
- *   
+ *
  *     <StateManager initial={false}>
  *       {(isOpen, setOpen) => (
  *         <Section
- *           title="Progress — bar track and fill"
+ *           title="Context: primary"
  *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
  *         >
+ *           <p>
+ *             The project's brand hue (the color the user picked for their DatoCMS project) at full strength. Reach for it on the main call-to-action button on a page, and on badges or navigation bars that need to stand out.
+ *           </p>
  *           <Swatches
  *             tokens={[
- *               '--color--progress--track',
- *               '--color--progress--fill',
- *               '--color--progress--fill-hover',
+ *               ['--color--primary--surface', 'Resting background of a primary call-to-action button'],
+ *               ['--color--primary--surface-hover', 'Hovered primary button background'],
+ *               ['--color--primary--surface-active', 'Pressed primary button background'],
+ *               ['--color--primary--surface-muted', 'Muted variant of the primary surface'],
+ *               ['--color--primary--ink', 'Text and icon color sitting on a primary surface'],
+ *               ['--color--primary--border', 'Thin border drawn on top of a primary surface'],
  *             ]}
  *           />
  *         </Section>
  *       )}
  *     </StateManager>
- *   
+ *
  *     <StateManager initial={false}>
  *       {(isOpen, setOpen) => (
  *         <Section
- *           title="Tooltip — small dark floating labels"
+ *           title="Context: tinted"
  *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
  *         >
+ *           <p>
+ *             A subtle wash of the same project brand hue for secondary actions and chips: quieter than primary, still clearly on-brand.
+ *           </p>
  *           <Swatches
  *             tokens={[
- *               '--color--tooltip--surface',
- *               '--color--tooltip--surface-hover',
- *               '--color--tooltip--ink',
- *               '--color--tooltip--ink-subtle',
+ *               ['--color--tinted--surface', 'Resting background of secondary brand-tinted buttons'],
+ *               ['--color--tinted--surface-hover', 'Hovered tinted button background'],
+ *               ['--color--tinted--surface-active', 'Pressed tinted button background'],
+ *               ['--color--tinted--ink', 'Text and icon color on a tinted surface'],
+ *               ['--color--tinted--border', 'Thin border drawn on top of a tinted surface'],
  *             ]}
  *           />
  *         </Section>
  *       )}
  *     </StateManager>
- *   
+ *
  *     <StateManager initial={false}>
  *       {(isOpen, setOpen) => (
  *         <Section
- *           title="Code — dark code blocks, logs, error traces"
+ *           title="Context: accent"
  *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
  *         >
- *           <Swatches tokens={['--color--code--surface', '--color--code--ink']} />
+ *           <p>
+ *             A different stop on the same project brand hue, picked to stand out against neutral chrome without competing with the primary call-to-action. Good for accent badges, highlighted cards and small inline action chips.
+ *           </p>
+ *           <Swatches
+ *             tokens={[
+ *               ['--color--accent--surface', 'Background of badges and accent-colored inline panels'],
+ *               ['--color--accent--ink', 'Text and icon color sitting on an accent surface'],
+ *             ]}
+ *           />
  *         </Section>
  *       )}
  *     </StateManager>
- *   
+ *
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Context: selected"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <p>
+ *             The active selection state: the highlighted entry in a list or tree, the currently picked option in a radio or choice group, the chosen card in a gallery.
+ *           </p>
+ *           <Swatches
+ *             tokens={[
+ *               ['--color--selected--surface', 'Background of the currently active entry in a list or tree'],
+ *               ['--color--selected--surface-hover', 'Hover on an entry that is already selected'],
+ *               ['--color--selected--ink', 'Text and icon color inside the selected entry'],
+ *               ['--color--selected--border', 'Border or outline ring drawn around a selected option or card'],
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Context: disabled"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <p>
+ *             The flat, low-contrast pair applied to non-interactive controls: disabled buttons, disabled selects and disabled toggles.
+ *           </p>
+ *           <Swatches
+ *             tokens={[
+ *               ['--color--disabled--surface', 'Background of a disabled button or control'],
+ *               ['--color--disabled--ink', 'Label and icon color on a disabled control'],
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Context: danger"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <p>
+ *             Reserved for destructive actions, such as Delete, Remove or Reset operations.
+ *           </p>
+ *           <Swatches
+ *             tokens={[
+ *               ['--color--danger--surface', 'Background of destructive action buttons like Delete'],
+ *               ['--color--danger--ink', 'Text and icon color on a danger surface'],
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Context: focus"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <p>
+ *             The keyboard-focus ring drawn around inputs, buttons and any other focusable control. Pair <code>border</code> on the element itself with <code>outline</code> as a soft halo.
+ *           </p>
+ *           <Swatches
+ *             tokens={[
+ *               ['--color--focus--border', 'Border color of the focused element'],
+ *               ['--color--focus--outline', 'Soft outline ring drawn around the focused element'],
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Feedback"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <p>
+ *             Validation states for forms and notifications: red for failures, yellow for warnings, green for successes. Each set follows the same four-property shape (ink, border, outline, surface), so you can swap the tone without touching layout.
+ *           </p>
+ *           <Swatches
+ *             tokens={[
+ *               ['--color--feedback-fail--ink', 'Error message text and the icon on an invalid field'],
+ *               ['--color--feedback-fail--border', 'Border around an invalid input or alert toast'],
+ *               ['--color--feedback-fail--outline', 'Soft halo around an invalid field on focus'],
+ *               ['--color--feedback-fail--surface', 'Background of error banners and alert toasts'],
+ *               ['--color--feedback-warning--ink', 'Text on warning banners and warning toasts'],
+ *               ['--color--feedback-warning--border', 'Border around warning banners and modified-state pills'],
+ *               ['--color--feedback-warning--outline', 'Soft halo for warning emphasis'],
+ *               ['--color--feedback-warning--surface', 'Background of warning banners and plugin notices'],
+ *               ['--color--feedback-success--ink', 'Text on success toasts and success banners'],
+ *               ['--color--feedback-success--border', 'Border around success banners'],
+ *               ['--color--feedback-success--outline', 'Soft halo for success emphasis'],
+ *               ['--color--feedback-success--surface', 'Background of success toasts'],
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Context: highlight"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <p>
+ *             The yellow marker pen for inline rich-text highlights inside Structured Text editors.
+ *           </p>
+ *           <Swatches
+ *             tokens={[
+ *               ['--color--highlight--surface', 'Background of a highlighted span inside a rich text editor'],
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Diffs"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <p>
+ *             Content-versioning palette across three intents: green for added, red for removed, blue for changed. Inline text diffs use the surface tint; block-level revision panels use the outline. For positive/negative rule indicators, the left-border tone depends on whether the rule was just edited: a subtle ink when stable, a vivid one when freshly changed. The changed variant has no ink stops, since rule borders are only ever green or red.
+ *           </p>
+ *           <Swatches
+ *             tokens={[
+ *               ['--color--diff-added--surface', 'Background of inline added text inside a text diff'],
+ *               ['--color--diff-added--outline', 'Outline drawn around a block-level added revision panel'],
+ *               ['--color--diff-added--ink', 'Left-border color of a positive rule when it was recently changed (vivid)'],
+ *               ['--color--diff-added--ink-subtle', 'Left-border color of a positive rule when it was not recently changed'],
+ *               ['--color--diff-removed--surface', 'Background of inline removed text inside a text diff'],
+ *               ['--color--diff-removed--outline', 'Outline drawn around a block-level removed revision panel'],
+ *               ['--color--diff-removed--ink', 'Left-border color of a negative rule when it was recently changed (vivid)'],
+ *               ['--color--diff-removed--ink-subtle', 'Left-border color of a negative rule when it was not recently changed'],
+ *               ['--color--diff-changed--surface', 'Background of inline changed text inside a text diff'],
+ *               ['--color--diff-changed--outline', 'Outline drawn around a block-level changed revision panel'],
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Status"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <p>
+ *             Publishing-workflow status dots. Ink-only because the colored dot is the whole marker, no surface or border needed.
+ *           </p>
+ *           <Swatches
+ *             kind="text"
+ *             tokens={[
+ *               ['--color--status-draft--ink', 'Dot color for records that exist only as a draft'],
+ *               ['--color--status-outdated--ink', 'Dot color for published records with unpublished changes'],
+ *               ['--color--status-published--ink', 'Dot color for fully published records'],
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Backdrop and overlay"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <p>
+ *             Two scrims for two jobs. The backdrop is the full-screen dim painted behind a modal dialog. The overlay is the lighter scrim that sits on top of media or thumbnails and hosts reversed buttons designed to read against dark imagery.
+ *           </p>
+ *           <Swatches
+ *             tokens={[
+ *               ['--color--backdrop--surface', 'Full-screen dim behind modals and dialogs'],
+ *               ['--color--backdrop--ink', 'Icon color for controls drawn directly on the backdrop, e.g. a modal close button'],
+ *               ['--color--overlay--surface', 'Scrim painted over media thumbnails and image cards'],
+ *               ['--color--overlay--surface-hover', 'Hover background of a reversed button floating on dark media'],
+ *               ['--color--overlay--surface-active', 'Pressed background of a reversed button on dark media'],
+ *               ['--color--overlay--ink', 'Text and icon color inside reversed buttons on overlay surfaces'],
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Stacked"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <p>
+ *             Layered dark inline areas, the kind used for asset uploaders and audio/video players. The wrapper paints the base surface; an inner detail panel sits a layer up; transparent action buttons gain visibility on hover and press.
+ *           </p>
+ *           <Swatches
+ *             tokens={[
+ *               ['--color--stacked--surface', 'Base layer of a dark inline panel'],
+ *               ['--color--stacked--surface-upper', 'Inner detail panel sitting one layer above the base'],
+ *               ['--color--stacked--surface-action', 'Resting background of action buttons inside a stacked panel (transparent)'],
+ *               ['--color--stacked--surface-action-hover', 'Hovered action button inside a stacked panel'],
+ *               ['--color--stacked--surface-action-active', 'Pressed action button inside a stacked panel'],
+ *               ['--color--stacked--ink', 'Main text and values on a stacked surface'],
+ *               ['--color--stacked--ink-subtle', 'Field labels and secondary text on a stacked surface'],
+ *               ['--color--stacked--border', 'Column rules and dividers inside a stacked panel'],
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Progress"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <p>
+ *             Horizontal progress bars used to report quota usage, upload advancement and similar percentage indicators.
+ *           </p>
+ *           <Swatches
+ *             tokens={[
+ *               ['--color--progress--track', 'Empty portion of the bar (the background track)'],
+ *               ['--color--progress--fill', 'Filled portion of the bar, drawn in the brand color'],
+ *               ['--color--progress--fill-hover', 'Fill color when the bar is hovered'],
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Tooltip"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <p>
+ *             Small dark floating labels: the plain tooltip shown on hover, and the keyboard-hint variant that pairs a description with a keyboard shortcut.
+ *           </p>
+ *           <Swatches
+ *             tokens={[
+ *               ['--color--tooltip--surface', 'Background of standard and keyboard-hint tooltips'],
+ *               ['--color--tooltip--surface-hover', 'Hover background for interactive controls living inside a tooltip'],
+ *               ['--color--tooltip--ink', 'Primary text inside a tooltip'],
+ *               ['--color--tooltip--ink-subtle', 'Secondary text inside a tooltip, e.g. the keyboard shortcut hint'],
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *
+ *     <StateManager initial={false}>
+ *       {(isOpen, setOpen) => (
+ *         <Section
+ *           title="Code"
+ *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
+ *         >
+ *           <p>
+ *             The dark monospaced surface used by build logs, error traces and other terminal-style output.
+ *           </p>
+ *           <Swatches
+ *             tokens={[
+ *               ['--color--code--surface', 'Background of code blocks, log panes and error traces'],
+ *               ['--color--code--ink', 'Monospaced text color rendered on a code surface'],
+ *             ]}
+ *           />
+ *         </Section>
+ *       )}
+ *     </StateManager>
+ *
  *     <StateManager initial={false}>
  *       {(isOpen, setOpen) => (
  *         <Section
  *           title="Scrollbar"
  *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
  *         >
- *           <Swatches tokens={['--color--scrollbar--fill']} />
- *         </Section>
- *       )}
- *     </StateManager>
- *   
- *     <StateManager initial={false}>
- *       {(isOpen, setOpen) => (
- *         <Section
- *           title="Shadow composites — drop-in box-shadow values"
- *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
- *         >
+ *           <p>
+ *             Tint applied globally to the native scrollbar thumb. Most visible in Firefox and on systems that keep scrollbars always on.
+ *           </p>
  *           <Swatches
- *             kind="shadow"
- *             tokens={['--shadow--raised', '--shadow--floating', '--shadow--lifted', '--shadow--ambient']}
+ *             tokens={[
+ *               ['--color--scrollbar--fill', 'Color of the native scrollbar thumb across the whole app'],
+ *             ]}
  *           />
  *         </Section>
  *       )}
@@ -407,213 +496,57 @@ export type CanvasProps = {
  * </Canvas>;
  * ```
  *
- * @example Typography CSS variables
+ * @example Shadows
  *
- * Typography is a foundational element in UI design. Good typography
- * establishes a strong, cohesive visual hierarchy and presents content clearly
- * and efficiently to users. Within the `Canvas` component, a set of CSS
- * variables is available allowing your plugin to conform to the overall
- * look&feel of DatoCMS:
+ * Four ready-made `box-shadow` composites (raised, floating, lifted, ambient). Drop them straight into a `box-shadow` property.
  *
  * ```js
  * <Canvas ctx={ctx}>
- *   <table>
- *     <tbody>
- *       <tr>
- *         <td>
- *           <code>--font-size-xxs</code>
- *         </td>
- *         <td>
- *           <div style={{ fontSize: 'var(--font-size-xxs)' }}>
- *             Size XXS
- *           </div>
- *         </td>
- *       </tr>
- *       <tr>
- *         <td>
- *           <code>--font-size-xs</code>
- *         </td>
- *         <td>
- *           <div style={{ fontSize: 'var(--font-size-xs)' }}>Size XS</div>
- *         </td>
- *       </tr>
- *       <tr>
- *         <td>
- *           <code>--font-size-s</code>
- *         </td>
- *         <td>
- *           <div style={{ fontSize: 'var(--font-size-s)' }}>Size S</div>
- *         </td>
- *       </tr>
- *       <tr>
- *         <td>
- *           <code>--font-size-m</code>
- *         </td>
- *         <td>
- *           <div style={{ fontSize: 'var(--font-size-m)' }}>Size M</div>
- *         </td>
- *       </tr>
- *       <tr>
- *         <td>
- *           <code>--font-size-l</code>
- *         </td>
- *         <td>
- *           <div
- *             style={{
- *               fontSize: 'var(--font-size-l)',
- *               fontWeight: 'var(--font-weight-bold)',
- *             }}
- *           >
- *             Size L
- *           </div>
- *         </td>
- *       </tr>
- *       <tr>
- *         <td>
- *           <code>--font-size-xl</code>
- *         </td>
- *         <td>
- *           <div
- *             style={{
- *               fontSize: 'var(--font-size-xl)',
- *               fontWeight: 'var(--font-weight-bold)',
- *             }}
- *           >
- *             Size XL
- *           </div>
- *         </td>
- *       </tr>
- *       <tr>
- *         <td>
- *           <code>--font-size-xxl</code>
- *         </td>
- *         <td>
- *           <div
- *             style={{
- *               fontSize: 'var(--font-size-xxl)',
- *               fontWeight: 'var(--font-weight-bold)',
- *             }}
- *           >
- *             Size XXL
- *           </div>
- *         </td>
- *       </tr>
- *       <tr>
- *         <td>
- *           <code>--font-size-xxxl</code>
- *         </td>
- *         <td>
- *           <div
- *             style={{
- *               fontSize: 'var(--font-size-xxxl)',
- *               fontWeight: 'var(--font-weight-bold)',
- *             }}
- *           >
- *             Size XXXL
- *           </div>
- *         </td>
- *       </tr>
- *     </tbody>
- *   </table>
+ *   <Swatches
+ *     kind="shadow"
+ *     tokens={['--shadow--raised', '--shadow--floating', '--shadow--lifted', '--shadow--ambient']}
+ *   />
  * </Canvas>;
  * ```
  *
- * @example Spacing CSS variables
+ * @example Typography
  *
- * The following CSS variables are available as well, to mimick the spacing
- * between elements used by the main DatoCMS application. Negative spacing
- * variables are available too (`--negative-spacing-<SIZE>`).
+ * Typography is a foundational element in UI design. Good typography establishes a strong, cohesive visual hierarchy and presents content clearly and efficiently to users. Within the `Canvas` component, a set of CSS variables is available allowing your plugin to conform to the overall look&feel of DatoCMS:
  *
  * ```js
  * <Canvas ctx={ctx}>
- *   <table>
- *     <tbody>
- *       <tr>
- *         <td>
- *           <code>--spacing-s</code>
- *         </td>
- *         <td>
- *           <div
- *             style={{
- *               background: 'var(--color--accent--surface)',
- *               width: 'var(--spacing-s)',
- *               height: 'var(--spacing-s)',
- *             }}
- *           />
- *         </td>
- *       </tr>
- *       <tr>
- *         <td>
- *           <code>--spacing-m</code>
- *         </td>
- *         <td>
- *           <div
- *             style={{
- *               background: 'var(--color--accent--surface)',
- *               width: 'var(--spacing-m)',
- *               height: 'var(--spacing-m)',
- *             }}
- *           />
- *         </td>
- *       </tr>
- *       <tr>
- *         <td>
- *           <code>--spacing-l</code>
- *         </td>
- *         <td>
- *           <div
- *             style={{
- *               background: 'var(--color--accent--surface)',
- *               width: 'var(--spacing-l)',
- *               height: 'var(--spacing-l)',
- *             }}
- *           />
- *         </td>
- *       </tr>
- *       <tr>
- *         <td>
- *           <code>--spacing-xl</code>
- *         </td>
- *         <td>
- *           <div
- *             style={{
- *               background: 'var(--color--accent--surface)',
- *               width: 'var(--spacing-xl)',
- *               height: 'var(--spacing-xl)',
- *             }}
- *           />
- *         </td>
- *       </tr>
- *       <tr>
- *         <td>
- *           <code>--spacing-xxl</code>
- *         </td>
- *         <td>
- *           <div
- *             style={{
- *               background: 'var(--color--accent--surface)',
- *               width: 'var(--spacing-xxl)',
- *               height: 'var(--spacing-xxl)',
- *             }}
- *           />
- *         </td>
- *       </tr>
- *       <tr>
- *         <td>
- *           <code>--spacing-xxxl</code>
- *         </td>
- *         <td>
- *           <div
- *             style={{
- *               background: 'var(--color--accent--surface)',
- *               width: 'var(--spacing-xxxl)',
- *               height: 'var(--spacing-xxxl)',
- *             }}
- *           />
- *         </td>
- *       </tr>
- *     </tbody>
- *   </table>
+ *   <Swatches
+ *     kind="font-size"
+ *     tokens={[
+ *       '--font-size-xxs',
+ *       '--font-size-xs',
+ *       '--font-size-s',
+ *       '--font-size-m',
+ *       '--font-size-l',
+ *       '--font-size-xl',
+ *       '--font-size-xxl',
+ *       '--font-size-xxxl',
+ *     ]}
+ *   />
+ * </Canvas>;
+ * ```
+ *
+ * @example Spacing
+ *
+ * The following CSS variables are available as well, to mimick the spacing between elements used by the main DatoCMS application. Negative spacing variables are available too (`--negative-spacing-<SIZE>`).
+ *
+ * ```js
+ * <Canvas ctx={ctx}>
+ *   <Spacings
+ *     tokens={[
+ *       '--spacing-s',
+ *       '--spacing-m',
+ *       '--spacing-l',
+ *       '--spacing-xl',
+ *       '--spacing-xxl',
+ *       '--spacing-xxxl',
+ *     ]}
+ *   />
  * </Canvas>;
  * ```
  */

--- a/packages/react-ui/src/Canvas/index.tsx
+++ b/packages/react-ui/src/Canvas/index.tsx
@@ -104,7 +104,7 @@ export type CanvasProps = {
  *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
  *         >
  *           <p>
- *             One-level tokens that work on any neutral page. The <code>surface</code>, <code>ink</code> and <code>border</code> families cover the page background, body text and dividers; the <code>surface-raised</code> variants belong to the elevated layer used by modals, dropdowns and popovers.
+ *             One-level tokens that work on any neutral page. The <code>surface</code>, <code>ink</code> and <code>border</code> families cover the page background, body text and dividers; the <code>surface-raised</code> variants belong to the elevated layer used by modals, dropdowns and popovers. The tone-on-neutral inks (<code>ink-danger</code>, <code>ink-warning</code>, <code>ink-success</code>) color text and icons on a neutral surface; inside a toned panel use that context's own ink instead.
  *           </p>
  *           <Swatches
  *             tokens={[
@@ -120,7 +120,10 @@ export type CanvasProps = {
  *               ['--color--ink-muted', 'Deemphasized text that should recede'],
  *               ['--color--ink-placeholder', 'Empty-input placeholder text'],
  *               ['--color--ink-primary', 'Theme-colored text and icons for branded labels'],
- *               ['--color--ink-accent', 'Inline links and accent text'],
+ *               ['--color--ink-link', 'Inline links and accent text'],
+ *               ['--color--ink-danger', 'Error text or icon on a neutral surface'],
+ *               ['--color--ink-warning', 'Warning text or icon on a neutral surface'],
+ *               ['--color--ink-success', 'Success text or icon on a neutral surface'],
  *               ['--color--ink-disabled', 'Label color on disabled inputs and buttons'],
  *               ['--color--border', 'Default 1px divider between cards, rows and sections'],
  *               ['--color--border-hover', 'Border of an input or card when hovered'],
@@ -137,7 +140,7 @@ export type CanvasProps = {
  *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
  *         >
  *           <p>
- *             The project's brand hue (the color the user picked for their DatoCMS project) at full strength. Reach for it on the main call-to-action button on a page, and on badges or navigation bars that need to stand out.
+ *             The project's brand hue (the color the user picked for their DatoCMS project) at full strength. Reach for it on the main call-to-action button on a page, and on badges or navigation bars that need to stand out. The <code>surface-secondary</code> variant is a quieter brand surface step (for accent badges and inline action chips) that keeps the same white <code>ink</code>.
  *           </p>
  *           <Swatches
  *             tokens={[
@@ -145,7 +148,8 @@ export type CanvasProps = {
  *               ['--color--primary--surface-hover', 'Hovered primary button background'],
  *               ['--color--primary--surface-active', 'Pressed primary button background'],
  *               ['--color--primary--surface-muted', 'Muted variant of the primary surface'],
- *               ['--color--primary--ink', 'Text and icon color sitting on a primary surface'],
+ *               ['--color--primary--surface-secondary', 'Quieter brand surface for accent badges and inline chips'],
+ *               ['--color--primary--ink', 'Text and icon color sitting on any primary surface'],
  *               ['--color--primary--border', 'Thin border drawn on top of a primary surface'],
  *             ]}
  *           />
@@ -156,38 +160,19 @@ export type CanvasProps = {
  *     <StateManager initial={false}>
  *       {(isOpen, setOpen) => (
  *         <Section
- *           title="Context: tinted"
+ *           title="Context: primary-soft"
  *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
  *         >
  *           <p>
- *             A subtle wash of the same project brand hue for secondary actions and chips: quieter than primary, still clearly on-brand.
+ *             A soft panel in the same project brand hue: a pale brand surface paired with saturated brand ink. Quieter than primary, still clearly on-brand, for secondary actions, chips and tinted callouts.
  *           </p>
  *           <Swatches
  *             tokens={[
- *               ['--color--tinted--surface', 'Resting background of secondary brand-tinted buttons'],
- *               ['--color--tinted--surface-hover', 'Hovered tinted button background'],
- *               ['--color--tinted--surface-active', 'Pressed tinted button background'],
- *               ['--color--tinted--ink', 'Text and icon color on a tinted surface'],
- *               ['--color--tinted--border', 'Thin border drawn on top of a tinted surface'],
- *             ]}
- *           />
- *         </Section>
- *       )}
- *     </StateManager>
- *
- *     <StateManager initial={false}>
- *       {(isOpen, setOpen) => (
- *         <Section
- *           title="Context: accent"
- *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
- *         >
- *           <p>
- *             A different stop on the same project brand hue, picked to stand out against neutral chrome without competing with the primary call-to-action. Good for accent badges, highlighted cards and small inline action chips.
- *           </p>
- *           <Swatches
- *             tokens={[
- *               ['--color--accent--surface', 'Background of badges and accent-colored inline panels'],
- *               ['--color--accent--ink', 'Text and icon color sitting on an accent surface'],
+ *               ['--color--primary-soft--surface', 'Resting background of secondary brand-tinted buttons'],
+ *               ['--color--primary-soft--surface-hover', 'Hovered tinted button background'],
+ *               ['--color--primary-soft--surface-active', 'Pressed tinted button background'],
+ *               ['--color--primary-soft--ink', 'Text and icon color on a soft brand surface'],
+ *               ['--color--primary-soft--border', 'Thin border drawn on top of a soft brand surface'],
  *             ]}
  *           />
  *         </Section>
@@ -275,26 +260,26 @@ export type CanvasProps = {
  *     <StateManager initial={false}>
  *       {(isOpen, setOpen) => (
  *         <Section
- *           title="Feedback"
+ *           title="Signal tones"
  *           collapsible={{ isOpen, onToggle: () => setOpen((v) => !v) }}
  *         >
  *           <p>
- *             Validation states for forms and notifications: red for failures, yellow for warnings, green for successes. Each set follows the same four-property shape (ink, border, outline, surface), so you can swap the tone without touching layout.
+ *             Soft panels for validation states and notifications: red for failures, amber for warnings, green for successes. Each <code>-soft</code> context is a pale surface paired with saturated ink, following the same four-property shape (surface, ink, border, outline), so you can swap the tone without touching layout. For a colored message on a plain neutral surface, reach for the standalone <code>ink-danger</code>, <code>ink-warning</code> and <code>ink-success</code> instead.
  *           </p>
  *           <Swatches
  *             tokens={[
- *               ['--color--feedback-fail--ink', 'Error message text and the icon on an invalid field'],
- *               ['--color--feedback-fail--border', 'Border around an invalid input or alert toast'],
- *               ['--color--feedback-fail--outline', 'Soft halo around an invalid field on focus'],
- *               ['--color--feedback-fail--surface', 'Background of error banners and alert toasts'],
- *               ['--color--feedback-warning--ink', 'Text on warning banners and warning toasts'],
- *               ['--color--feedback-warning--border', 'Border around warning banners and modified-state pills'],
- *               ['--color--feedback-warning--outline', 'Soft halo for warning emphasis'],
- *               ['--color--feedback-warning--surface', 'Background of warning banners and plugin notices'],
- *               ['--color--feedback-success--ink', 'Text on success toasts and success banners'],
- *               ['--color--feedback-success--border', 'Border around success banners'],
- *               ['--color--feedback-success--outline', 'Soft halo for success emphasis'],
- *               ['--color--feedback-success--surface', 'Background of success toasts'],
+ *               ['--color--danger-soft--surface', 'Background of error banners and alert toasts'],
+ *               ['--color--danger-soft--ink', 'Error message text and the icon inside an error panel'],
+ *               ['--color--danger-soft--border', 'Border around an invalid input or alert toast'],
+ *               ['--color--danger-soft--outline', 'Soft halo around an invalid field on focus'],
+ *               ['--color--warning-soft--surface', 'Background of warning banners and plugin notices'],
+ *               ['--color--warning-soft--ink', 'Text inside warning banners and warning toasts'],
+ *               ['--color--warning-soft--border', 'Border around warning banners and modified-state pills'],
+ *               ['--color--warning-soft--outline', 'Soft halo for warning emphasis'],
+ *               ['--color--success-soft--surface', 'Background of success toasts'],
+ *               ['--color--success-soft--ink', 'Text inside success toasts and success banners'],
+ *               ['--color--success-soft--border', 'Border around success banners'],
+ *               ['--color--success-soft--outline', 'Soft halo for success emphasis'],
  *             ]}
  *           />
  *         </Section>

--- a/packages/react-ui/src/Canvas/index.tsx
+++ b/packages/react-ui/src/Canvas/index.tsx
@@ -34,283 +34,186 @@ export type CanvasProps = {
 };
 
 /**
- * @example Color palette CSS variables
+ * @example Semantic color token CSS variables
  *
- * Within the `Canvas` component, a color palette is made available as a set of
- * CSS variables, allowing you to conform to the theme of the current
- * environment:
+ * Inside `Canvas`, the host exposes a full semantic color palette as CSS
+ * custom properties. Components should reference these tokens directly —
+ * they adapt to the user's active theme (including dark mode)
+ * automatically.
+ *
+ * ### How to read a token name
+ *
+ * ```
+ * --color--{property}                 // standalone (one -- after color)
+ * --color--{context}--{property}      // context pair (two -- after color)
+ * ```
+ *
+ * **Properties** — `surface` (backgrounds), `ink` (text/icons),
+ * `border` (1px lines), `outline` (focus rings), plus `fill` / `track`
+ * for progress bars.
+ *
+ * **Standalone** tokens work on any neutral page. **Contexts** are
+ * self-contained environments: always pair a `surface` with the `ink`,
+ * `border`, and hover states from the *same* context. Never mix — e.g.
+ * don't put `--color--primary--ink` on `--color--danger--surface`.
+ *
+ * Non-color tokens `--shadow--raised` / `--shadow--floating` /
+ * `--shadow--lifted` / `--shadow--ambient` are ready-made `box-shadow`
+ * composites.
  *
  * ```js
  * <Canvas ctx={ctx}>
- *   <Section title="Text colors">
- *     <table>
- *       <tbody>
- *         <tr>
- *           <td>
- *             <code>--base-body-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--base-body-color)',
- *               }}
- *             />
- *           </td>
+ *   <Section title="Standalone — use on any neutral page">
+ *     <table><tbody>
+ *       {[
+ *         ['--color--surface',          'Default page background'],
+ *         ['--color--surface-hover',    'Hovered row / list item'],
+ *         ['--color--surface-muted',    'Muted section / card background'],
+ *         ['--color--ink',              'Primary text'],
+ *         ['--color--ink-subtle',       'Secondary text / captions'],
+ *         ['--color--ink-hover',        'Text under hover'],
+ *         ['--color--ink-muted',        'De-emphasized text'],
+ *         ['--color--ink-placeholder',  'Input placeholder text'],
+ *         ['--color--ink-primary',      'Brand-highlighted text / icons'],
+ *         ['--color--ink-accent',       'Links / accent text'],
+ *         ['--color--ink-disabled',     'Disabled text'],
+ *         ['--color--border',           'Default 1px border'],
+ *         ['--color--border-hover',     'Border under hover'],
+ *       ].map(([t, d]) => (
+ *         <tr key={t}>
+ *           <td><code>{t}</code></td>
+ *           <td style={{ color: 'var(--color--ink-subtle)' }}>{d}</td>
+ *           <td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td>
  *         </tr>
- *         <tr>
- *           <td>
- *             <code>--light-body-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--light-body-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--placeholder-body-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--placeholder-body-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *       </tbody>
- *     </table>
+ *       ))}
+ *     </tbody></table>
  *   </Section>
- *   <Section title="UI colors">
- *     <table>
- *       <tbody>
- *         <tr>
- *           <td>
- *             <code>--light-bg-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--light-bg-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--lighter-bg-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--lighter-bg-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--disabled-bg-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--disabled-bg-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--border-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--border-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--darker-border-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--darker-border-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--alert-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--alert-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--warning-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--warning-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--notice-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--notice-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--warning-bg-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--warning-bg-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--add-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--add-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--remove-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--remove-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *       </tbody>
- *     </table>
+ *
+ *   <Section title="Context: raised — modals, dropdowns, popovers">
+ *     <table><tbody>
+ *       {['--color--raised--surface', '--color--raised--surface-hover', '--color--raised--surface-active']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
  *   </Section>
- *   <Section title="Project-specific colors">
- *     <table>
- *       <tbody>
- *         <tr>
- *           <td>
- *             <code>--accent-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--accent-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--primary-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--primary-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--light-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--light-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *         <tr>
- *           <td>
- *             <code>--dark-color</code>
- *           </td>
- *           <td width="30%">
- *             <div
- *               style={{
- *                 width: '30px',
- *                 height: '30px',
- *                 background: 'var(--dark-color)',
- *               }}
- *             />
- *           </td>
- *         </tr>
- *       </tbody>
- *     </table>
+ *
+ *   <Section title="Context: primary — main call-to-action buttons, badges, nav">
+ *     <table><tbody>
+ *       {['--color--primary--surface', '--color--primary--surface-hover', '--color--primary--surface-active', '--color--primary--surface-muted', '--color--primary--ink', '--color--primary--border']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Context: tinted — subtle brand-tinted surfaces">
+ *     <table><tbody>
+ *       {['--color--tinted--surface', '--color--tinted--surface-hover', '--color--tinted--surface-active', '--color--tinted--ink', '--color--tinted--border']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Context: accent, selected, disabled, danger">
+ *     <table><tbody>
+ *       {['--color--accent--surface', '--color--accent--ink',
+ *         '--color--selected--surface', '--color--selected--ink', '--color--selected--border',
+ *         '--color--disabled--surface', '--color--disabled--ink',
+ *         '--color--danger--surface', '--color--danger--ink']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Context: focus — focus rings and outlines">
+ *     <table><tbody>
+ *       {['--color--focus--border', '--color--focus--outline']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Feedback — validation and form states">
+ *     <table><tbody>
+ *       {['--color--feedback-fail--ink', '--color--feedback-fail--border', '--color--feedback-fail--outline', '--color--feedback-fail--surface',
+ *         '--color--feedback-warning--ink', '--color--feedback-warning--border', '--color--feedback-warning--outline', '--color--feedback-warning--surface',
+ *         '--color--feedback-success--ink', '--color--feedback-success--border', '--color--feedback-success--outline', '--color--feedback-success--surface']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Context: highlight — rich text inline highlights">
+ *     <table><tbody>
+ *       {['--color--highlight--surface']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Diffs — content versioning (added / removed / changed)">
+ *     <table><tbody>
+ *       {['--color--diff-added--surface', '--color--diff-added--outline', '--color--diff-added--ink', '--color--diff-added--ink-subtle',
+ *         '--color--diff-removed--surface', '--color--diff-removed--outline', '--color--diff-removed--ink', '--color--diff-removed--ink-subtle',
+ *         '--color--diff-changed--surface', '--color--diff-changed--outline']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Status — publishing workflow badges (ink-only)">
+ *     <table><tbody>
+ *       {['--color--status-draft--ink', '--color--status-outdated--ink', '--color--status-published--ink']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td><span style={{ color: `var(${t})`, fontWeight: 'bold' }}>Sample text</span></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Backdrop & overlay — scrims and floating UI">
+ *     <table><tbody>
+ *       {['--color--backdrop--surface', '--color--backdrop--ink',
+ *         '--color--overlay--surface', '--color--overlay--surface-hover', '--color--overlay--surface-active', '--color--overlay--ink']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Stacked — dark layered UI (uploaders, media players)">
+ *     <p>Stacked gives you layered dark surfaces (base → upper) plus action buttons, borders and ink tones. Use it when a dark inline panel needs internal hierarchy.</p>
+ *     <table><tbody>
+ *       {['--color--stacked--surface', '--color--stacked--surface-upper',
+ *         '--color--stacked--surface-action', '--color--stacked--surface-action-hover', '--color--stacked--surface-action-active',
+ *         '--color--stacked--ink', '--color--stacked--ink-subtle', '--color--stacked--border']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Progress — bar track and fill">
+ *     <table><tbody>
+ *       {['--color--progress--track', '--color--progress--fill', '--color--progress--fill-hover']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Tooltip — small dark floating labels">
+ *     <table><tbody>
+ *       {['--color--tooltip--surface', '--color--tooltip--surface-hover', '--color--tooltip--ink', '--color--tooltip--ink-subtle']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Code — dark code blocks, logs, error traces">
+ *     <table><tbody>
+ *       {['--color--code--surface', '--color--code--ink']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Scrollbar">
+ *     <table><tbody>
+ *       {['--color--scrollbar--fill']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Shadow composites — drop-in box-shadow values">
+ *     <div style={{ display: 'flex', gap: 'var(--spacing-l)', padding: 'var(--spacing-l)' }}>
+ *       {['--shadow--raised', '--shadow--floating', '--shadow--lifted', '--shadow--ambient'].map((t) => (
+ *         <div key={t} style={{ textAlign: 'center' }}>
+ *           <div style={{ width: '80px', height: '80px', background: 'var(--color--surface)', borderRadius: '4px', boxShadow: `var(${t})` }} />
+ *           <code style={{ display: 'block', marginTop: 'var(--spacing-s)', fontSize: 'var(--font-size-xs)' }}>{t}</code>
+ *         </div>
+ *       ))}
+ *     </div>
  *   </Section>
  * </Canvas>;
  * ```
@@ -443,7 +346,7 @@ export type CanvasProps = {
  *         <td>
  *           <div
  *             style={{
- *               background: 'var(--accent-color)',
+ *               background: 'var(--color--accent--surface)',
  *               width: 'var(--spacing-s)',
  *               height: 'var(--spacing-s)',
  *             }}
@@ -457,7 +360,7 @@ export type CanvasProps = {
  *         <td>
  *           <div
  *             style={{
- *               background: 'var(--accent-color)',
+ *               background: 'var(--color--accent--surface)',
  *               width: 'var(--spacing-m)',
  *               height: 'var(--spacing-m)',
  *             }}
@@ -471,7 +374,7 @@ export type CanvasProps = {
  *         <td>
  *           <div
  *             style={{
- *               background: 'var(--accent-color)',
+ *               background: 'var(--color--accent--surface)',
  *               width: 'var(--spacing-l)',
  *               height: 'var(--spacing-l)',
  *             }}
@@ -485,7 +388,7 @@ export type CanvasProps = {
  *         <td>
  *           <div
  *             style={{
- *               background: 'var(--accent-color)',
+ *               background: 'var(--color--accent--surface)',
  *               width: 'var(--spacing-xl)',
  *               height: 'var(--spacing-xl)',
  *             }}
@@ -499,7 +402,7 @@ export type CanvasProps = {
  *         <td>
  *           <div
  *             style={{
- *               background: 'var(--accent-color)',
+ *               background: 'var(--color--accent--surface)',
  *               width: 'var(--spacing-xxl)',
  *               height: 'var(--spacing-xxl)',
  *             }}
@@ -513,7 +416,7 @@ export type CanvasProps = {
  *         <td>
  *           <div
  *             style={{
- *               background: 'var(--accent-color)',
+ *               background: 'var(--color--accent--surface)',
  *               width: 'var(--spacing-xxxl)',
  *               height: 'var(--spacing-xxxl)',
  *             }}

--- a/packages/react-ui/src/Canvas/index.tsx
+++ b/packages/react-ui/src/Canvas/index.tsx
@@ -36,84 +36,186 @@ export type CanvasProps = {
 /**
  * @example Semantic color token CSS variables
  *
- * Within the `Canvas` component, semantic color tokens are made available as
- * CSS variables, allowing you to conform to the theme of the current
- * environment (including dark mode):
+ * Inside `Canvas`, the host exposes a full semantic color palette as CSS
+ * custom properties. Components should reference these tokens directly —
+ * they adapt to the user's active theme (including dark mode)
+ * automatically.
+ *
+ * ### How to read a token name
+ *
+ * ```
+ * --color--{property}                 // standalone (one -- after color)
+ * --color--{context}--{property}      // context pair (two -- after color)
+ * ```
+ *
+ * **Properties** — `surface` (backgrounds), `ink` (text/icons),
+ * `border` (1px lines), `outline` (focus rings), plus `fill` / `track`
+ * for progress bars.
+ *
+ * **Standalone** tokens work on any neutral page. **Contexts** are
+ * self-contained environments: always pair a `surface` with the `ink`,
+ * `border`, and hover states from the *same* context. Never mix — e.g.
+ * don't put `--color--primary--ink` on `--color--danger--surface`.
+ *
+ * Non-color tokens `--shadow--elevated` / `--shadow--float` /
+ * `--shadow--ambient` are ready-made `box-shadow` composites.
  *
  * ```js
  * <Canvas ctx={ctx}>
- *   <Section title="Standalone">
- *     <table>
- *       <tbody>
- *         {[
- *           '--color--surface',
- *           '--color--surface-hover',
- *           '--color--surface-muted',
- *           '--color--ink',
- *           '--color--ink-subtle',
- *           '--color--ink-placeholder',
- *           '--color--ink-accent',
- *           '--color--border',
- *           '--color--border-hover',
- *         ].map((v) => (
- *           <tr key={v}>
- *             <td><code>{v}</code></td>
- *             <td width="30%">
- *               <div style={{ width: '30px', height: '30px', background: `var(${v})` }} />
- *             </td>
- *           </tr>
- *         ))}
- *       </tbody>
- *     </table>
+ *   <Section title="Standalone — use on any neutral page">
+ *     <table><tbody>
+ *       {[
+ *         ['--color--surface',          'Default page background'],
+ *         ['--color--surface-hover',    'Hovered row / list item'],
+ *         ['--color--surface-muted',    'Muted section / card background'],
+ *         ['--color--ink',              'Primary text'],
+ *         ['--color--ink-subtle',       'Secondary text / captions'],
+ *         ['--color--ink-hover',        'Text under hover'],
+ *         ['--color--ink-muted',        'De-emphasized text'],
+ *         ['--color--ink-placeholder',  'Input placeholder text'],
+ *         ['--color--ink-primary',      'Brand-highlighted text / icons'],
+ *         ['--color--ink-accent',       'Links / accent text'],
+ *         ['--color--ink-disabled',     'Disabled text'],
+ *         ['--color--border',           'Default 1px border'],
+ *         ['--color--border-hover',     'Border under hover'],
+ *       ].map(([t, d]) => (
+ *         <tr key={t}>
+ *           <td><code>{t}</code></td>
+ *           <td style={{ color: 'var(--color--ink-subtle)' }}>{d}</td>
+ *           <td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td>
+ *         </tr>
+ *       ))}
+ *     </tbody></table>
  *   </Section>
- *   <Section title="Contexts">
- *     <table>
- *       <tbody>
- *         {[
- *           '--color--primary--surface',
- *           '--color--primary--ink',
- *           '--color--tinted--surface',
- *           '--color--tinted--ink',
- *           '--color--accent--surface',
- *           '--color--accent--ink',
- *           '--color--selected--surface',
- *           '--color--danger--surface',
- *           '--color--danger--ink',
- *           '--color--disabled--surface',
- *           '--color--disabled--ink',
- *           '--color--focus--border',
- *           '--color--focus--outline',
- *         ].map((v) => (
- *           <tr key={v}>
- *             <td><code>{v}</code></td>
- *             <td width="30%">
- *               <div style={{ width: '30px', height: '30px', background: `var(${v})` }} />
- *             </td>
- *           </tr>
- *         ))}
- *       </tbody>
- *     </table>
+ *
+ *   <Section title="Context: raised — modals, dropdowns, popovers">
+ *     <table><tbody>
+ *       {['--color--raised--surface', '--color--raised--surface-hover', '--color--raised--surface-active']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
  *   </Section>
- *   <Section title="Feedback">
- *     <table>
- *       <tbody>
- *         {[
- *           '--color--feedback-fail--ink',
- *           '--color--feedback-fail--border',
- *           '--color--feedback-warning--ink',
- *           '--color--feedback-warning--surface',
- *           '--color--feedback-success--ink',
- *           '--color--feedback-success--border',
- *         ].map((v) => (
- *           <tr key={v}>
- *             <td><code>{v}</code></td>
- *             <td width="30%">
- *               <div style={{ width: '30px', height: '30px', background: `var(${v})` }} />
- *             </td>
- *           </tr>
- *         ))}
- *       </tbody>
- *     </table>
+ *
+ *   <Section title="Context: primary — main call-to-action buttons, badges, nav">
+ *     <table><tbody>
+ *       {['--color--primary--surface', '--color--primary--surface-hover', '--color--primary--surface-active', '--color--primary--surface-muted', '--color--primary--ink', '--color--primary--border']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Context: tinted — subtle brand-tinted surfaces">
+ *     <table><tbody>
+ *       {['--color--tinted--surface', '--color--tinted--surface-hover', '--color--tinted--surface-active', '--color--tinted--ink']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Context: accent, selected, disabled, danger, enterprise">
+ *     <table><tbody>
+ *       {['--color--accent--surface', '--color--accent--ink',
+ *         '--color--selected--surface', '--color--selected--ink', '--color--selected--border',
+ *         '--color--disabled--surface', '--color--disabled--ink',
+ *         '--color--danger--surface', '--color--danger--ink',
+ *         '--color--enterprise--surface']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Context: focus — focus rings and outlines">
+ *     <table><tbody>
+ *       {['--color--focus--border', '--color--focus--outline']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Feedback — validation and form states">
+ *     <table><tbody>
+ *       {['--color--feedback-fail--ink', '--color--feedback-fail--border', '--color--feedback-fail--outline',
+ *         '--color--feedback-warning--ink', '--color--feedback-warning--surface', '--color--feedback-warning--border',
+ *         '--color--feedback-success--ink', '--color--feedback-success--border']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Context: highlight — rich text inline highlights">
+ *     <table><tbody>
+ *       {['--color--highlight--surface']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Diffs — content versioning (added / removed / changed)">
+ *     <table><tbody>
+ *       {['--color--diff-added--surface', '--color--diff-removed--surface', '--color--diff-changed--surface',
+ *         '--color--diff-added--surface-subtle', '--color--diff-removed--surface-subtle', '--color--diff-changed--surface-subtle',
+ *         '--color--diff-added--outline-subtle', '--color--diff-removed--outline-subtle', '--color--diff-changed--outline-subtle',
+ *         '--color--diff-changed--border', '--color--diff-changed--border-negative']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Status — publishing workflow badges (ink-only)">
+ *     <table><tbody>
+ *       {['--color--status-draft--ink', '--color--status-outdated--ink', '--color--status-published--ink']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td><span style={{ color: `var(${t})`, fontWeight: 'bold' }}>Sample text</span></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Backdrop & overlay — scrims and floating UI">
+ *     <table><tbody>
+ *       {['--color--backdrop--surface', '--color--backdrop--ink',
+ *         '--color--overlay--surface', '--color--overlay--surface-subtle', '--color--overlay--ink']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Stacked — dark layered UI (uploaders, media players)">
+ *     <p>Stacked gives you three layers of depth (base → surface → raised) plus buttons, borders and a translucent fill. Use it when a dark inline panel needs internal hierarchy.</p>
+ *     <table><tbody>
+ *       {['--color--stacked--surface-base', '--color--stacked--surface', '--color--stacked--surface-raised',
+ *         '--color--stacked--surface-hover', '--color--stacked--surface-translucent',
+ *         '--color--stacked--surface-button', '--color--stacked--surface-button-active',
+ *         '--color--stacked--ink', '--color--stacked--ink-subtle', '--color--stacked--border']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Progress — bar track and fill">
+ *     <table><tbody>
+ *       {['--color--progress--track', '--color--progress--fill', '--color--progress--fill-hover']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Tooltip — small dark floating labels">
+ *     <table><tbody>
+ *       {['--color--tooltip--surface', '--color--tooltip--surface-hover', '--color--tooltip--ink', '--color--tooltip--ink-subtle']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Code — dark code blocks, logs, error traces">
+ *     <table><tbody>
+ *       {['--color--code--surface', '--color--code--ink']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Shadow colors and scrollbar">
+ *     <table><tbody>
+ *       {['--color--shadow-subtle', '--color--shadow', '--color--shadow-strong', '--color--scrollbar']
+ *         .map((t) => (<tr key={t}><td><code>{t}</code></td><td width="40"><div style={{ width: '30px', height: '30px', background: `var(${t})`, border: '1px solid var(--color--border)' }} /></td></tr>))}
+ *     </tbody></table>
+ *   </Section>
+ *
+ *   <Section title="Shadow composites — drop-in box-shadow values">
+ *     <div style={{ display: 'flex', gap: 'var(--spacing-l)', padding: 'var(--spacing-l)' }}>
+ *       {['--shadow--elevated', '--shadow--float', '--shadow--ambient'].map((t) => (
+ *         <div key={t} style={{ textAlign: 'center' }}>
+ *           <div style={{ width: '80px', height: '80px', background: 'var(--color--surface)', borderRadius: '4px', boxShadow: `var(${t})` }} />
+ *           <code style={{ display: 'block', marginTop: 'var(--spacing-s)', fontSize: 'var(--font-size-xs)' }}>{t}</code>
+ *         </div>
+ *       ))}
+ *     </div>
  *   </Section>
  * </Canvas>;
  * ```

--- a/packages/react-ui/src/Canvas/styles.module.css
+++ b/packages/react-ui/src/Canvas/styles.module.css
@@ -30,13 +30,13 @@
   --darker-border-color-rgb-components: 215, 215, 215;
   --darker-border-color: var(--color--border-hover);
   --alert-color-rgb-components: 255, 94, 73;
-  --alert-color: var(--color--feedback-fail--ink);
+  --alert-color: var(--color--ink-danger);
   --warning-color-rgb-components: 255, 215, 0;
-  --warning-color: var(--color--feedback-warning--ink);
+  --warning-color: var(--color--ink-warning);
   --notice-color-rgb-components: 70, 215, 0;
-  --notice-color: var(--color--feedback-success--ink);
+  --notice-color: var(--color--ink-success);
   --warning-bg-color-rgb-components: 255, 255, 229;
-  --warning-bg-color: var(--color--feedback-warning--surface);
+  --warning-bg-color: var(--color--warning-soft--surface);
   --add-color-rgb-components: 76, 176, 109;
   --add-color: var(--color--diff-added--surface);
   --remove-color-rgb-components: 235, 87, 106;

--- a/packages/react-ui/src/Canvas/styles.module.css
+++ b/packages/react-ui/src/Canvas/styles.module.css
@@ -1,33 +1,46 @@
 .themeVariables {
-  /* Colors */
+  /**
+   * @deprecated LEGACY COLOR VARIABLES — DO NOT USE IN NEW CODE.
+   *
+   * The color variables below are kept strictly for backward compatibility
+   * with third-party plugins authored before the semantic color token
+   * system. Each one now resolves to its closest semantic token, so it
+   * follows the active theme (including dark mode).
+   *
+   * The colors in this block will be removed in a future major version.
+   * Migrate to the `--color--*` semantic tokens (see the `Canvas` JSDoc
+   * for the full list). The non-color tokens further below (fonts, spacing,
+   * font-sizes, easings) are stable and will remain.
+   */
+  /* Colors (deprecated) */
   --base-body-color-rgb-components: 52, 54, 58;
-  --base-body-color: rgb(var(--base-body-color-rgb-components));
+  --base-body-color: var(--color--ink);
   --light-body-color-rgb-components: 132, 132, 132;
-  --light-body-color: rgb(var(--light-body-color-rgb-components));
+  --light-body-color: var(--color--ink-subtle);
   --placeholder-body-color-rgb-components: 198, 198, 198;
-  --placeholder-body-color: rgb(var(--placeholder-body-color-rgb-components));
+  --placeholder-body-color: var(--color--ink-placeholder);
   --light-bg-color-rgb-components: 245, 245, 245;
-  --light-bg-color: rgb(var(--light-bg-color-rgb-components));
+  --light-bg-color: var(--color--surface-muted);
   --lighter-bg-color-rgb-components: 248, 248, 248;
-  --lighter-bg-color: rgb(var(--lighter-bg-color-rgb-components));
+  --lighter-bg-color: var(--color--surface-muted);
   --disabled-bg-color-rgb-components: 237, 237, 237;
-  --disabled-bg-color: rgb(var(--disabled-bg-color-rgb-components));
+  --disabled-bg-color: var(--color--disabled--surface);
   --border-color-rgb-components: 240, 240, 240;
-  --border-color: rgb(var(--border-color-rgb-components));
+  --border-color: var(--color--border);
   --darker-border-color-rgb-components: 215, 215, 215;
-  --darker-border-color: rgb(var(--darker-border-color-rgb-components));
+  --darker-border-color: var(--color--border-hover);
   --alert-color-rgb-components: 255, 94, 73;
-  --alert-color: rgb(var(--alert-color-rgb-components));
+  --alert-color: var(--color--feedback-fail--ink);
   --warning-color-rgb-components: 255, 215, 0;
-  --warning-color: rgb(var(--warning-color-rgb-components));
+  --warning-color: var(--color--feedback-warning--ink);
   --notice-color-rgb-components: 70, 215, 0;
-  --notice-color: rgb(var(--notice-color-rgb-components));
+  --notice-color: var(--color--feedback-success--ink);
   --warning-bg-color-rgb-components: 255, 255, 229;
-  --warning-bg-color: rgb(var(--warning-bg-color-rgb-components));
+  --warning-bg-color: var(--color--feedback-warning--surface);
   --add-color-rgb-components: 76, 176, 109;
-  --add-color: rgb(var(--add-color-rgb-components));
+  --add-color: var(--color--diff-added--surface);
   --remove-color-rgb-components: 235, 87, 106;
-  --remove-color: rgb(var(--remove-color-rgb-components));
+  --remove-color: var(--color--diff-removed--surface);
 
   /* Fonts */
   --base-font-family:
@@ -39,6 +52,7 @@
   --font-weight-bold: 500;
 
   /* Spacing */
+  --spacing-xs: calc(0.25 * 12 * 0.0625rem);
   --spacing-s: calc(0.5 * 12 * 0.0625rem);
   --spacing-m: calc(1 * 12 * 0.0625rem);
   --spacing-l: calc(2 * 12 * 0.0625rem);
@@ -46,6 +60,7 @@
   --spacing-xxl: calc(5 * 12 * 0.0625rem);
   --spacing-xxxl: calc(8 * 12 * 0.0625rem);
 
+  --negative-spacing-xs: calc(-0.25 * 12 * 0.0625rem);
   --negative-spacing-s: calc(-0.5 * 12 * 0.0625rem);
   --negative-spacing-m: calc(-1 * 12 * 0.0625rem);
   --negative-spacing-l: calc(-2 * 12 * 0.0625rem);
@@ -71,7 +86,8 @@
   font-family: var(--base-font-family);
   -webkit-text-size-adjust: 100%;
   line-height: 1.5;
-  color: var(--base-body-color);
+  color: var(--color--ink);
+  background: var(--color--surface);
   font-size: var(--font-size-m);
   text-rendering: optimizeLegibility;
 }

--- a/packages/react-ui/src/Canvas/styles.module.css
+++ b/packages/react-ui/src/Canvas/styles.module.css
@@ -1,33 +1,89 @@
 .themeVariables {
-  /* Colors */
+  /**
+   * @deprecated LEGACY COLOR VARIABLES — DO NOT USE IN NEW CODE.
+   *
+   * The color variables below are kept strictly for backward compatibility
+   * with third-party plugins authored before the semantic color token
+   * system. Each one now resolves to its closest semantic token (so it
+   * follows the active theme, including dark mode), falling back to the
+   * original hardcoded light-mode value if the token is unavailable.
+   *
+   * The colors in this block will be removed in a future major version.
+   * Migrate to the `--color--*` semantic tokens (see the `Canvas` JSDoc
+   * for the full list). The non-color tokens further below (fonts, spacing,
+   * font-sizes, easings) are stable and will remain.
+   */
+  /* Colors (deprecated) */
   --base-body-color-rgb-components: 52, 54, 58;
-  --base-body-color: rgb(var(--base-body-color-rgb-components));
+  --base-body-color: var(
+    --color--ink,
+    rgb(var(--base-body-color-rgb-components))
+  );
   --light-body-color-rgb-components: 132, 132, 132;
-  --light-body-color: rgb(var(--light-body-color-rgb-components));
+  --light-body-color: var(
+    --color--ink-subtle,
+    rgb(var(--light-body-color-rgb-components))
+  );
   --placeholder-body-color-rgb-components: 198, 198, 198;
-  --placeholder-body-color: rgb(var(--placeholder-body-color-rgb-components));
+  --placeholder-body-color: var(
+    --color--ink-placeholder,
+    rgb(var(--placeholder-body-color-rgb-components))
+  );
   --light-bg-color-rgb-components: 245, 245, 245;
-  --light-bg-color: rgb(var(--light-bg-color-rgb-components));
+  --light-bg-color: var(
+    --color--surface-muted,
+    rgb(var(--light-bg-color-rgb-components))
+  );
   --lighter-bg-color-rgb-components: 248, 248, 248;
-  --lighter-bg-color: rgb(var(--lighter-bg-color-rgb-components));
+  --lighter-bg-color: var(
+    --color--surface-muted,
+    rgb(var(--lighter-bg-color-rgb-components))
+  );
   --disabled-bg-color-rgb-components: 237, 237, 237;
-  --disabled-bg-color: rgb(var(--disabled-bg-color-rgb-components));
+  --disabled-bg-color: var(
+    --color--disabled--surface,
+    rgb(var(--disabled-bg-color-rgb-components))
+  );
   --border-color-rgb-components: 240, 240, 240;
-  --border-color: rgb(var(--border-color-rgb-components));
+  --border-color: var(
+    --color--border,
+    rgb(var(--border-color-rgb-components))
+  );
   --darker-border-color-rgb-components: 215, 215, 215;
-  --darker-border-color: rgb(var(--darker-border-color-rgb-components));
+  --darker-border-color: var(
+    --color--border-hover,
+    rgb(var(--darker-border-color-rgb-components))
+  );
   --alert-color-rgb-components: 255, 94, 73;
-  --alert-color: rgb(var(--alert-color-rgb-components));
+  --alert-color: var(
+    --color--feedback-fail--ink,
+    rgb(var(--alert-color-rgb-components))
+  );
   --warning-color-rgb-components: 255, 215, 0;
-  --warning-color: rgb(var(--warning-color-rgb-components));
+  --warning-color: var(
+    --color--feedback-warning--ink,
+    rgb(var(--warning-color-rgb-components))
+  );
   --notice-color-rgb-components: 70, 215, 0;
-  --notice-color: rgb(var(--notice-color-rgb-components));
+  --notice-color: var(
+    --color--feedback-success--ink,
+    rgb(var(--notice-color-rgb-components))
+  );
   --warning-bg-color-rgb-components: 255, 255, 229;
-  --warning-bg-color: rgb(var(--warning-bg-color-rgb-components));
+  --warning-bg-color: var(
+    --color--feedback-warning--surface,
+    rgb(var(--warning-bg-color-rgb-components))
+  );
   --add-color-rgb-components: 76, 176, 109;
-  --add-color: rgb(var(--add-color-rgb-components));
+  --add-color: var(
+    --color--diff-added--surface,
+    rgb(var(--add-color-rgb-components))
+  );
   --remove-color-rgb-components: 235, 87, 106;
-  --remove-color: rgb(var(--remove-color-rgb-components));
+  --remove-color: var(
+    --color--diff-removed--surface,
+    rgb(var(--remove-color-rgb-components))
+  );
 
   /* Fonts */
   --base-font-family:
@@ -39,6 +95,7 @@
   --font-weight-bold: 500;
 
   /* Spacing */
+  --spacing-xs: calc(0.25 * 12 * 0.0625rem);
   --spacing-s: calc(0.5 * 12 * 0.0625rem);
   --spacing-m: calc(1 * 12 * 0.0625rem);
   --spacing-l: calc(2 * 12 * 0.0625rem);
@@ -46,6 +103,7 @@
   --spacing-xxl: calc(5 * 12 * 0.0625rem);
   --spacing-xxxl: calc(8 * 12 * 0.0625rem);
 
+  --negative-spacing-xs: calc(-0.25 * 12 * 0.0625rem);
   --negative-spacing-s: calc(-0.5 * 12 * 0.0625rem);
   --negative-spacing-m: calc(-1 * 12 * 0.0625rem);
   --negative-spacing-l: calc(-2 * 12 * 0.0625rem);
@@ -71,7 +129,8 @@
   font-family: var(--base-font-family);
   -webkit-text-size-adjust: 100%;
   line-height: 1.5;
-  color: var(--base-body-color);
+  color: var(--color--ink);
+  background: var(--color--surface);
   font-size: var(--font-size-m);
   text-rendering: optimizeLegibility;
 }

--- a/packages/react-ui/src/ContextInspector/styles.module.css
+++ b/packages/react-ui/src/ContextInspector/styles.module.css
@@ -3,7 +3,7 @@
 }
 
 .panel {
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--color--border);
 }
 
 .panelHandle {
@@ -12,20 +12,20 @@
   box-sizing: border-box;
   width: 100%;
   font-weight: var(--font-weight-bold);
-  background: var(--light-bg-color);
+  background: var(--color--surface-muted);
   border: 0;
   padding: 5px 10px;
   cursor: pointer;
 
   &:hover {
-    background: var(--lighter-bg-color);
+    background: var(--color--surface-hover);
   }
 }
 
 .panelBody {
   padding: 20px;
-  border-left: 1px solid var(--border-color);
-  border-right: 1px solid var(--border-color);
+  border-left: 1px solid var(--color--border);
+  border-right: 1px solid var(--color--border);
 }
 
 .groupDescription {
@@ -35,12 +35,12 @@
 }
 
 .propertyGroup {
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--color--border);
   border-radius: 5px;
 }
 
 .propertyOrMethod {
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--color--border);
   line-height: 1.2;
 
   p {
@@ -57,7 +57,7 @@
 
   pre {
     padding: 15px;
-    background: var(--light-bg-color);
+    background: var(--color--surface-muted);
     font-size: 0.8em;
     margin: 0;
     max-height: 240px;
@@ -69,7 +69,7 @@
   display: block;
   text-decoration: none;
   font-weight: bold;
-  color: var(--light-body-color);
+  color: var(--color--ink-subtle);
   font-family: var(--monospaced-font-family);
   font-size: 0.9em;
   margin-bottom: 5px;
@@ -81,7 +81,7 @@
 
 .propertyOrMethodExampleActions {
   padding: 15px;
-  background: white;
+  background: var(--color--surface);
   display: flex;
 
   > * {

--- a/packages/react-ui/src/Dropdown/styles.module.css
+++ b/packages/react-ui/src/Dropdown/styles.module.css
@@ -40,7 +40,7 @@
   &:focus {
     outline: 0;
     border-color: var(--color--focus--border);
-    box-shadow: 0 0 0 3px var(--color--focus--outline);
+    box-shadow: 0 0 0 4px var(--color--focus--outline);
   }
 }
 
@@ -120,10 +120,10 @@
 }
 
 .Dropdown__menu__option--is-dangerous {
-  color: var(--color--feedback-fail--ink);
+  color: var(--color--danger--ink);
 
   svg {
-    fill: var(--color--feedback-fail--ink);
+    fill: var(--color--danger--ink);
   }
 
   &:hover,
@@ -241,9 +241,9 @@
 }
 
 .Dropdown__menu__option__icon--delete {
-  color: var(--color--feedback-fail--ink);
+  color: var(--color--danger--ink);
   svg {
-    fill: var(--color--feedback-fail--ink);
+    fill: var(--color--danger--ink);
   }
 }
 

--- a/packages/react-ui/src/Dropdown/styles.module.css
+++ b/packages/react-ui/src/Dropdown/styles.module.css
@@ -10,35 +10,37 @@
 
 .Dropdown__menu__search {
   padding: 7px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--color--border);
 }
 
 .Dropdown__menu__search__input {
   display: block;
   box-sizing: border-box;
   width: 100%;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--color--border);
   appearance: none;
+  background-color: var(--color--surface);
   background-image: none;
   transition: border 0.2s var(--material-ease);
   resize: none;
   font-family: inherit;
+  color: inherit;
   padding: 8px;
   border-radius: 3px;
   font-size: 0.9em;
 
   &::placeholder {
-    color: var(--placeholder-body-color);
+    color: var(--color--ink-placeholder);
   }
 
   &:hover {
-    border-color: var(--darker-border-color);
+    border-color: var(--color--border-hover);
   }
 
   &:focus {
     outline: 0;
-    border-color: var(--accent-color);
-    box-shadow: 0 0 0 3px var(--semi-transparent-accent-color);
+    border-color: var(--color--focus--border);
+    box-shadow: 0 0 0 3px var(--color--focus--outline);
   }
 }
 
@@ -49,8 +51,8 @@
 
 .Dropdown__menu {
   min-width: 200px;
-  background-color: white;
-  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
+  background-color: var(--color--raised--surface);
+  box-shadow: 0 3px 10px var(--color--shadow);
   border-radius: 4px;
   margin-bottom: var(--spacing-xl);
   padding: 1px 0;
@@ -64,8 +66,8 @@
 
 .Dropdown__menu__group__title {
   padding: 5px 15px 3px;
-  color: var(--light-body-color);
-  background-color: var(--light-bg-color);
+  color: var(--color--ink-subtle);
+  background-color: var(--color--surface-muted);
   text-transform: uppercase;
   font-size: var(--font-size-xs);
 }
@@ -77,7 +79,7 @@
 .Dropdown__menu__text {
   text-align: left;
   padding: 4px 15px;
-  color: var(--light-body-color);
+  color: var(--color--ink-subtle);
   position: relative;
   display: block;
   line-height: 1.2;
@@ -86,7 +88,7 @@
 .Dropdown__menu__option {
   text-align: left;
   padding: 4px 15px;
-  color: var(--base-body-color);
+  color: var(--color--ink);
   position: relative;
   text-decoration: none;
   white-space: nowrap;
@@ -95,7 +97,7 @@
 
   &:hover,
   &:focus {
-    background-color: var(--light-bg-color);
+    background-color: var(--color--surface-hover);
   }
 
   & > a {
@@ -106,7 +108,7 @@
 }
 
 .Dropdown__menu__option--is-selected {
-  background-color: var(--light-bg-color);
+  background-color: var(--color--selected--surface);
 }
 
 .Dropdown__menu__option--is-disabled {
@@ -118,19 +120,19 @@
 }
 
 .Dropdown__menu__option--is-dangerous {
-  color: var(--alert-color);
+  color: var(--color--feedback-fail--ink);
 
   svg {
-    fill: var(--alert-color);
+    fill: var(--color--feedback-fail--ink);
   }
 
   &:hover,
   &:focus {
-    background-color: var(--alert-color);
-    color: white;
+    background-color: var(--color--danger--surface);
+    color: var(--color--danger--ink);
 
     svg {
-      fill: white;
+      fill: var(--color--danger--ink);
     }
   }
 }
@@ -161,7 +163,7 @@
     border-radius: 4px;
     height: 8px;
     width: 8px;
-    background-color: var(--alert-color);
+    background-color: var(--color--danger--surface);
   }
 }
 
@@ -186,8 +188,8 @@
     padding-right: 8px;
     display: inline-block;
     vertical-align: middle;
-    color: var(--light-body-color);
-    fill: var(--light-body-color);
+    color: var(--color--ink-subtle);
+    fill: var(--color--ink-subtle);
   }
 }
 
@@ -202,7 +204,7 @@
   cursor: pointer;
   line-height: inherit;
   background-color: transparent;
-  color: var(--base-body-color);
+  color: var(--color--ink);
   -webkit-appearance: none;
   -moz-appearance: none;
   box-sizing: border-box;
@@ -213,7 +215,7 @@
   width: auto;
   opacity: 0;
   line-height: 10px;
-  color: var(--light-body-color);
+  color: var(--color--ink-subtle);
   padding: 3px;
   font-size: 13px;
   position: relative;
@@ -234,21 +236,21 @@
   }
 
   svg {
-    fill: var(--light-body-color);
+    fill: var(--color--ink-subtle);
   }
 }
 
 .Dropdown__menu__option__icon--delete {
-  color: var(--alert-color);
+  color: var(--color--feedback-fail--ink);
   svg {
-    fill: var(--alert-color);
+    fill: var(--color--feedback-fail--ink);
   }
 }
 
 .Dropdown__menu__separator {
   margin: 8px 0;
   height: 1px;
-  background-color: var(--border-color);
+  background-color: var(--color--border);
 }
 
 .Dropdown__menu {

--- a/packages/react-ui/src/Dropdown/styles.module.css
+++ b/packages/react-ui/src/Dropdown/styles.module.css
@@ -10,35 +10,37 @@
 
 .Dropdown__menu__search {
   padding: 7px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--color--border);
 }
 
 .Dropdown__menu__search__input {
   display: block;
   box-sizing: border-box;
   width: 100%;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--color--border);
   appearance: none;
+  background-color: var(--color--surface);
   background-image: none;
   transition: border 0.2s var(--material-ease);
   resize: none;
   font-family: inherit;
+  color: inherit;
   padding: 8px;
   border-radius: 3px;
   font-size: 0.9em;
 
   &::placeholder {
-    color: var(--placeholder-body-color);
+    color: var(--color--ink-placeholder);
   }
 
   &:hover {
-    border-color: var(--darker-border-color);
+    border-color: var(--color--border-hover);
   }
 
   &:focus {
     outline: 0;
-    border-color: var(--accent-color);
-    box-shadow: 0 0 0 3px var(--semi-transparent-accent-color);
+    border-color: var(--color--focus--border);
+    box-shadow: 0 0 0 3px var(--color--focus--outline);
   }
 }
 
@@ -49,8 +51,8 @@
 
 .Dropdown__menu {
   min-width: 200px;
-  background-color: white;
-  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
+  background-color: var(--color--raised--surface);
+  box-shadow: var(--shadow--floating);
   border-radius: 4px;
   margin-bottom: var(--spacing-xl);
   padding: 1px 0;
@@ -64,8 +66,8 @@
 
 .Dropdown__menu__group__title {
   padding: 5px 15px 3px;
-  color: var(--light-body-color);
-  background-color: var(--light-bg-color);
+  color: var(--color--ink-subtle);
+  background-color: var(--color--surface-muted);
   text-transform: uppercase;
   font-size: var(--font-size-xs);
 }
@@ -77,7 +79,7 @@
 .Dropdown__menu__text {
   text-align: left;
   padding: 4px 15px;
-  color: var(--light-body-color);
+  color: var(--color--ink-subtle);
   position: relative;
   display: block;
   line-height: 1.2;
@@ -86,7 +88,7 @@
 .Dropdown__menu__option {
   text-align: left;
   padding: 4px 15px;
-  color: var(--base-body-color);
+  color: var(--color--ink);
   position: relative;
   text-decoration: none;
   white-space: nowrap;
@@ -95,7 +97,7 @@
 
   &:hover,
   &:focus {
-    background-color: var(--light-bg-color);
+    background-color: var(--color--surface-hover);
   }
 
   & > a {
@@ -106,7 +108,7 @@
 }
 
 .Dropdown__menu__option--is-selected {
-  background-color: var(--light-bg-color);
+  background-color: var(--color--selected--surface);
 }
 
 .Dropdown__menu__option--is-disabled {
@@ -118,19 +120,19 @@
 }
 
 .Dropdown__menu__option--is-dangerous {
-  color: var(--alert-color);
+  color: var(--color--feedback-fail--ink);
 
   svg {
-    fill: var(--alert-color);
+    fill: var(--color--feedback-fail--ink);
   }
 
   &:hover,
   &:focus {
-    background-color: var(--alert-color);
-    color: white;
+    background-color: var(--color--danger--surface);
+    color: var(--color--danger--ink);
 
     svg {
-      fill: white;
+      fill: var(--color--danger--ink);
     }
   }
 }
@@ -161,7 +163,7 @@
     border-radius: 4px;
     height: 8px;
     width: 8px;
-    background-color: var(--alert-color);
+    background-color: var(--color--danger--surface);
   }
 }
 
@@ -186,8 +188,8 @@
     padding-right: 8px;
     display: inline-block;
     vertical-align: middle;
-    color: var(--light-body-color);
-    fill: var(--light-body-color);
+    color: var(--color--ink-subtle);
+    fill: var(--color--ink-subtle);
   }
 }
 
@@ -202,7 +204,7 @@
   cursor: pointer;
   line-height: inherit;
   background-color: transparent;
-  color: var(--base-body-color);
+  color: var(--color--ink);
   -webkit-appearance: none;
   -moz-appearance: none;
   box-sizing: border-box;
@@ -213,7 +215,7 @@
   width: auto;
   opacity: 0;
   line-height: 10px;
-  color: var(--light-body-color);
+  color: var(--color--ink-subtle);
   padding: 3px;
   font-size: 13px;
   position: relative;
@@ -234,21 +236,21 @@
   }
 
   svg {
-    fill: var(--light-body-color);
+    fill: var(--color--ink-subtle);
   }
 }
 
 .Dropdown__menu__option__icon--delete {
-  color: var(--alert-color);
+  color: var(--color--feedback-fail--ink);
   svg {
-    fill: var(--alert-color);
+    fill: var(--color--feedback-fail--ink);
   }
 }
 
 .Dropdown__menu__separator {
   margin: 8px 0;
   height: 1px;
-  background-color: var(--border-color);
+  background-color: var(--color--border);
 }
 
 .Dropdown__menu {

--- a/packages/react-ui/src/Dropdown/styles.module.css
+++ b/packages/react-ui/src/Dropdown/styles.module.css
@@ -51,7 +51,7 @@
 
 .Dropdown__menu {
   min-width: 200px;
-  background-color: var(--color--raised--surface);
+  background-color: var(--color--surface-raised);
   box-shadow: var(--shadow--floating);
   border-radius: 4px;
   margin-bottom: var(--spacing-xl);

--- a/packages/react-ui/src/FieldError/styles.module.css
+++ b/packages/react-ui/src/FieldError/styles.module.css
@@ -1,5 +1,5 @@
 .fieldError {
-  color: var(--alert-color);
+  color: var(--color--feedback-fail--ink);
   line-height: 1.2;
   font-size: var(--font-size-xs);
   margin-top: var(--spacing-s);

--- a/packages/react-ui/src/FieldError/styles.module.css
+++ b/packages/react-ui/src/FieldError/styles.module.css
@@ -1,5 +1,5 @@
 .fieldError {
-  color: var(--color--feedback-fail--ink);
+  color: var(--color--ink-danger);
   line-height: 1.2;
   font-size: var(--font-size-xs);
   margin-top: var(--spacing-s);

--- a/packages/react-ui/src/FieldHint/styles.module.css
+++ b/packages/react-ui/src/FieldHint/styles.module.css
@@ -1,5 +1,5 @@
 .fieldHint {
-  color: var(--light-body-color);
+  color: var(--color--ink-subtle);
   line-height: 1.2;
   font-size: var(--font-size-xs);
   margin-top: var(--spacing-s);

--- a/packages/react-ui/src/FormLabel/styles.module.css
+++ b/packages/react-ui/src/FormLabel/styles.module.css
@@ -12,7 +12,7 @@
 }
 
 .formLabel--error {
-  color: var(--color--feedback-fail--ink);
+  color: var(--color--ink-danger);
 }
 
 .formLabel__label {

--- a/packages/react-ui/src/FormLabel/styles.module.css
+++ b/packages/react-ui/src/FormLabel/styles.module.css
@@ -1,6 +1,6 @@
 .formLabel {
   display: flex;
-  color: var(--light-body-color);
+  color: var(--color--ink-subtle);
   margin-bottom: var(--spacing-s);
   align-items: center;
 
@@ -12,7 +12,7 @@
 }
 
 .formLabel--error {
-  color: var(--alert-color);
+  color: var(--color--feedback-fail--ink);
 }
 
 .formLabel__label {

--- a/packages/react-ui/src/HotKey/styles.module.css
+++ b/packages/react-ui/src/HotKey/styles.module.css
@@ -17,6 +17,6 @@
 
 .hotKeyKey {
   padding: 5px 8px;
-  background: var(--color--tinted--surface);
+  background: var(--color--primary-soft--surface);
   border-radius: 3px;
 }

--- a/packages/react-ui/src/HotKey/styles.module.css
+++ b/packages/react-ui/src/HotKey/styles.module.css
@@ -17,6 +17,6 @@
 
 .hotKeyKey {
   padding: 5px 8px;
-  background: var(--light-color);
+  background: var(--color--tinted--surface);
   border-radius: 3px;
 }

--- a/packages/react-ui/src/Section/index.tsx
+++ b/packages/react-ui/src/Section/index.tsx
@@ -75,27 +75,28 @@ export function Section({
       className={cn(s.Section, { [s['Section--highlighted']]: highlighted })}
     >
       <div
-        className={cn(s.Section__header, headerClassName)}
+        className={cn(
+          s.Section__header,
+          { [s['Section__header--clickable']]: collapsible },
+          headerClassName,
+        )}
         style={headerStyle}
+        onClick={collapsible ? collapsible.onToggle : undefined}
       >
         <div
-          className={cn(
-            s.Section__title,
-
-            titleClassName,
-          )}
+          className={cn(s.Section__title, titleClassName)}
           style={titleStyle}
         >
-          {collapsible && (
-            <button
-              type="button"
-              className={cn(s.Section__arrow, {
-                [s['Section__arrow--is-open']]: collapsible.isOpen,
-              })}
-              onClick={collapsible.onToggle}
-            />
-          )}
-          <div className={s.Section__title__content}>{title}</div>
+          <span className={s.Section__title__content}>
+            {collapsible && (
+              <div
+                className={cn(s.Section__arrow, {
+                  [s['Section__arrow--is-open']]: collapsible.isOpen,
+                })}
+              />
+            )}
+            {title}
+          </span>
         </div>
       </div>
       {(!collapsible || collapsible.isOpen) && children}

--- a/packages/react-ui/src/Section/styles.module.css
+++ b/packages/react-ui/src/Section/styles.module.css
@@ -9,7 +9,7 @@
   right: -30px;
   bottom: -20px;
   left: -30px;
-  box-shadow: 0 0 0 4px var(--accent-color);
+  box-shadow: 0 0 0 4px var(--color--focus--border);
   border-radius: 4px;
   animation: pageContentSectionHighligh 4s 0.25s ease-in-out forwards;
   pointer-events: none;
@@ -30,7 +30,7 @@
     left: 0;
     right: 0;
     height: 1px;
-    background-color: var(--border-color);
+    background-color: var(--color--border);
     z-index: 1;
   }
 }
@@ -42,7 +42,7 @@
   margin-right: var(--spacing-l);
   padding-left: var(--spacing-m);
   padding-right: var(--spacing-m);
-  background-color: white;
+  background-color: var(--color--surface);
   position: relative;
   z-index: 2;
   display: inline-flex;
@@ -66,7 +66,7 @@
     width: 0;
     border-top: 6px solid transparent;
     border-bottom: 6px solid transparent;
-    border-left: 6px solid var(--base-body-color);
+    border-left: 6px solid var(--color--ink);
     left: 14px;
     top: 50%;
     margin-top: -6px;
@@ -85,14 +85,14 @@
 
 @keyframes pageContentSectionHighligh {
   0% {
-    box-shadow: 0 0 0 4px var(--accent-color),
-      0 0 0 4px rgba(var(--accent-color-rgb-components), 0.7);
+    box-shadow: 0 0 0 4px var(--color--focus--border),
+      0 0 0 4px var(--color--focus--outline);
   }
   15% {
-    box-shadow: 0 0 0 4px var(--accent-color), 0 0 0 80px transparent;
+    box-shadow: 0 0 0 4px var(--color--focus--border), 0 0 0 80px transparent;
   }
   75% {
-    box-shadow: 0 0 0 4px var(--accent-color), 0 0 0 80px transparent;
+    box-shadow: 0 0 0 4px var(--color--focus--border), 0 0 0 80px transparent;
   }
   100% {
     box-shadow: 0 0 0 4px transparent, 0 0 0 80px transparent;

--- a/packages/react-ui/src/Section/styles.module.css
+++ b/packages/react-ui/src/Section/styles.module.css
@@ -1,5 +1,8 @@
 .Section {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-m);
 }
 
 .Section--highlighted:before {
@@ -19,44 +22,51 @@
 .Section__header {
   margin-left: var(--negative-spacing-l);
   margin-right: var(--negative-spacing-l);
-  margin-bottom: var(--spacing-l);
-  position: relative;
+}
 
-  &:before {
-    content: '';
-    display: block;
-    position: absolute;
-    top: 50%;
-    left: 0;
-    right: 0;
-    height: 1px;
-    background-color: var(--color--border);
-    z-index: 1;
+.Section__header--clickable {
+  cursor: pointer;
+  user-select: none;
+
+  &:hover .Section__arrow:before {
+    opacity: 0.7;
   }
 }
 
 .Section__title {
-  font-size: var(--font-size-l);
-  font-weight: var(--font-weight-bold);
-  margin-left: var(--spacing-m);
-  margin-right: var(--spacing-l);
-  padding-left: var(--spacing-m);
-  padding-right: var(--spacing-m);
-  background-color: var(--color--surface);
-  position: relative;
-  z-index: 2;
-  display: inline-flex;
+  display: flex;
+  gap: var(--spacing-m);
   align-items: center;
+
+  &:before,
+  &:after {
+    height: 1px;
+    content: '';
+    background-color: var(--color--border);
+  }
+
+  &:before {
+    width: calc(var(--spacing-l) - var(--spacing-m));
+  }
+
+  &:after {
+    flex: 1;
+    margin-right: var(--spacing-l);
+  }
 }
 
 .Section__title__content {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  font-size: var(--font-size-l);
+  font-weight: var(--font-weight-bold);
 }
 
 .Section__arrow {
-  all: initial;
+  position: relative;
   width: 15px;
   align-self: stretch;
-  cursor: pointer;
   margin-right: 0.3em;
 
   &:before {
@@ -67,15 +77,11 @@
     border-top: 6px solid transparent;
     border-bottom: 6px solid transparent;
     border-left: 6px solid var(--color--ink);
-    left: 14px;
+    left: 6px;
     top: 50%;
     margin-top: -6px;
     transition: transform 0.2s ease-out;
     transform-origin: 50% 50%;
-  }
-
-  &:hover:before {
-    opacity: 0.7;
   }
 }
 

--- a/packages/react-ui/src/SelectInput/index.tsx
+++ b/packages/react-ui/src/SelectInput/index.tsx
@@ -103,7 +103,7 @@ const useStyles = (isDisabled?: boolean, error?: boolean) => {
           ...provided,
           zIndex: 1000,
           minWidth: 250,
-          backgroundColor: 'var(--color--raised--surface)',
+          backgroundColor: 'var(--color--surface-raised)',
           boxShadow: 'var(--shadow--floating)',
         };
       },

--- a/packages/react-ui/src/SelectInput/index.tsx
+++ b/packages/react-ui/src/SelectInput/index.tsx
@@ -92,6 +92,11 @@ const useStyles = (isDisabled?: boolean, error?: boolean) => {
       multiValueRemove: (provided) => ({
         ...provided,
         cursor: 'pointer',
+        color: 'var(--color--tinted--ink)',
+        ':hover': {
+          backgroundColor: 'var(--color--tinted--surface-hover)',
+          color: 'var(--color--tinted--ink)',
+        },
       }),
       menu: (provided) => {
         return {
@@ -134,6 +139,7 @@ const useStyles = (isDisabled?: boolean, error?: boolean) => {
         ...provided,
         fontSize: 'inherit',
         padding: 3,
+        color: 'var(--color--tinted--ink)',
       }),
     };
   }, [isDisabled, error]);

--- a/packages/react-ui/src/SelectInput/index.tsx
+++ b/packages/react-ui/src/SelectInput/index.tsx
@@ -56,19 +56,19 @@ const useStyles = (isDisabled?: boolean, error?: boolean) => {
           return {
             ...result,
             borderColor: error
-              ? 'var(--color--feedback-fail--border)'
+              ? 'var(--color--danger-soft--border)'
               : 'var(--color--focus--border)',
             backgroundColor: isDisabled
               ? 'var(--color--disabled--surface)'
               : 'var(--color--surface)',
             boxShadow: `0 0 0 4px ${
               error
-                ? 'var(--color--feedback-fail--outline)'
+                ? 'var(--color--danger-soft--outline)'
                 : 'var(--color--focus--outline)'
             }`,
             '&:hover': {
               borderColor: error
-                ? 'var(--color--feedback-fail--border)'
+                ? 'var(--color--danger-soft--border)'
                 : 'var(--color--focus--border)',
             },
           };
@@ -77,14 +77,14 @@ const useStyles = (isDisabled?: boolean, error?: boolean) => {
         return {
           ...result,
           borderColor: error
-            ? 'var(--color--feedback-fail--border)'
+            ? 'var(--color--danger-soft--border)'
             : 'var(--color--border)',
           backgroundColor: isDisabled
             ? 'var(--color--disabled--surface)'
             : 'var(--color--surface)',
           '&:hover': {
             borderColor: error
-              ? 'var(--color--feedback-fail--border)'
+              ? 'var(--color--danger-soft--border)'
               : 'var(--color--border-hover)',
           },
         };
@@ -92,10 +92,10 @@ const useStyles = (isDisabled?: boolean, error?: boolean) => {
       multiValueRemove: (provided) => ({
         ...provided,
         cursor: 'pointer',
-        color: 'var(--color--tinted--ink)',
+        color: 'var(--color--primary-soft--ink)',
         ':hover': {
-          backgroundColor: 'var(--color--tinted--surface-hover)',
-          color: 'var(--color--tinted--ink)',
+          backgroundColor: 'var(--color--primary-soft--surface-hover)',
+          color: 'var(--color--primary-soft--ink)',
         },
       }),
       menu: (provided) => {
@@ -132,7 +132,7 @@ const useStyles = (isDisabled?: boolean, error?: boolean) => {
         return {
           ...provided,
           zIndex: 100,
-          backgroundColor: 'var(--color--tinted--surface)',
+          backgroundColor: 'var(--color--primary-soft--surface)',
           userSelect: 'none',
         };
       },
@@ -140,7 +140,7 @@ const useStyles = (isDisabled?: boolean, error?: boolean) => {
         ...provided,
         fontSize: 'inherit',
         padding: 3,
-        color: 'var(--color--tinted--ink)',
+        color: 'var(--color--primary-soft--ink)',
       }),
     };
   }, [isDisabled, error]);

--- a/packages/react-ui/src/SelectInput/index.tsx
+++ b/packages/react-ui/src/SelectInput/index.tsx
@@ -18,15 +18,15 @@ const themeConfig: ThemeConfig = (existing) => ({
   borderRadius: 0,
   colors: {
     ...existing.colors,
-    primary25: 'var(--semi-transparent-accent-color)',
+    primary25: 'var(--color--surface-hover)',
     // disabled
-    neutral10: 'var(--border-color)',
+    neutral10: 'var(--color--border)',
     // normal
-    neutral20: 'var(--border-color)',
+    neutral20: 'var(--color--border)',
     // focused
-    primary: 'var(--accent-color)',
+    primary: 'var(--color--focus--border)',
     // hover
-    neutral30: 'var(--darker-border-color)',
+    neutral30: 'var(--color--border-hover)',
   },
 });
 
@@ -35,7 +35,7 @@ const useStyles = (isDisabled?: boolean, error?: boolean) => {
     return {
       placeholder: (provided) => ({
         ...provided,
-        color: 'var(--placeholder-body-color)',
+        color: 'var(--color--ink-placeholder)',
       }),
       container: (provided) => {
         return {
@@ -55,57 +55,84 @@ const useStyles = (isDisabled?: boolean, error?: boolean) => {
         if (isFocused) {
           return {
             ...result,
-            borderColor: error ? 'var(--alert-color)' : 'var(--accent-color)',
-            backgroundColor: isDisabled ? 'var(--disabled-color)' : 'white',
+            borderColor: error
+              ? 'var(--color--feedback-fail--border)'
+              : 'var(--color--focus--border)',
+            backgroundColor: isDisabled
+              ? 'var(--color--disabled--surface)'
+              : 'var(--color--surface)',
             boxShadow: `0 0 0 3px ${
               error
-                ? 'rgba(var(--alert-color-rgb-components), 0.2)'
-                : 'var(--semi-transparent-accent-color)'
+                ? 'var(--color--feedback-fail--outline)'
+                : 'var(--color--focus--outline)'
             }`,
             '&:hover': {
-              borderColor: error ? 'var(--alert-color)' : 'var(--accent-color)',
+              borderColor: error
+                ? 'var(--color--feedback-fail--border)'
+                : 'var(--color--focus--border)',
             },
           };
         }
 
         return {
           ...result,
-          borderColor: error ? 'var(--alert-color)' : 'var(--border-color)',
-          backgroundColor: isDisabled ? 'var(--disabled-color)' : 'white',
+          borderColor: error
+            ? 'var(--color--feedback-fail--border)'
+            : 'var(--color--border)',
+          backgroundColor: isDisabled
+            ? 'var(--color--disabled--surface)'
+            : 'var(--color--surface)',
           '&:hover': {
             borderColor: error
-              ? 'var(--alert-color)'
-              : 'var(--darker-border-color)',
+              ? 'var(--color--feedback-fail--border)'
+              : 'var(--color--border-hover)',
           },
         };
       },
       multiValueRemove: (provided) => ({
         ...provided,
         cursor: 'pointer',
+        color: 'var(--color--tinted--ink)',
+        ':hover': {
+          backgroundColor: 'var(--color--tinted--surface-hover)',
+          color: 'var(--color--tinted--ink)',
+        },
       }),
       menu: (provided) => {
         return {
           ...provided,
           zIndex: 1000,
           minWidth: 250,
+          backgroundColor: 'var(--color--raised--surface)',
+          boxShadow: 'var(--shadow--floating)',
         };
       },
-      input: (provided) => {
-        const result = {
-          ...provided,
+      singleValue: (provided) => ({
+        ...provided,
+        color: 'var(--color--ink)',
+      }),
+      input: (provided) => ({
+        ...provided,
+        color: 'var(--color--ink)',
+        boxShadow: 'none',
+        'input:focus': {
           boxShadow: 'none',
-          'input:focus': {
-            boxShadow: 'none',
-          },
-        };
-
-        return result;
-      },
+        },
+      }),
+      option: (provided, { isFocused, isSelected }) => ({
+        ...provided,
+        backgroundColor: isSelected
+          ? 'var(--color--selected--surface)'
+          : isFocused
+            ? 'var(--color--surface-hover)'
+            : undefined,
+        color: 'var(--color--ink)',
+      }),
       multiValue: (provided) => {
         return {
           ...provided,
           zIndex: 100,
-          backgroundColor: 'var(--light-color)',
+          backgroundColor: 'var(--color--tinted--surface)',
           userSelect: 'none',
         };
       },
@@ -113,6 +140,7 @@ const useStyles = (isDisabled?: boolean, error?: boolean) => {
         ...provided,
         fontSize: 'inherit',
         padding: 3,
+        color: 'var(--color--tinted--ink)',
       }),
     };
   }, [isDisabled, error]);

--- a/packages/react-ui/src/SelectInput/index.tsx
+++ b/packages/react-ui/src/SelectInput/index.tsx
@@ -18,15 +18,15 @@ const themeConfig: ThemeConfig = (existing) => ({
   borderRadius: 0,
   colors: {
     ...existing.colors,
-    primary25: 'var(--semi-transparent-accent-color)',
+    primary25: 'var(--color--surface-hover)',
     // disabled
-    neutral10: 'var(--border-color)',
+    neutral10: 'var(--color--border)',
     // normal
-    neutral20: 'var(--border-color)',
+    neutral20: 'var(--color--border)',
     // focused
-    primary: 'var(--accent-color)',
+    primary: 'var(--color--focus--border)',
     // hover
-    neutral30: 'var(--darker-border-color)',
+    neutral30: 'var(--color--border-hover)',
   },
 });
 
@@ -35,7 +35,7 @@ const useStyles = (isDisabled?: boolean, error?: boolean) => {
     return {
       placeholder: (provided) => ({
         ...provided,
-        color: 'var(--placeholder-body-color)',
+        color: 'var(--color--ink-placeholder)',
       }),
       container: (provided) => {
         return {
@@ -55,27 +55,37 @@ const useStyles = (isDisabled?: boolean, error?: boolean) => {
         if (isFocused) {
           return {
             ...result,
-            borderColor: error ? 'var(--alert-color)' : 'var(--accent-color)',
-            backgroundColor: isDisabled ? 'var(--disabled-color)' : 'white',
+            borderColor: error
+              ? 'var(--color--feedback-fail--border)'
+              : 'var(--color--focus--border)',
+            backgroundColor: isDisabled
+              ? 'var(--color--disabled--surface)'
+              : 'var(--color--surface)',
             boxShadow: `0 0 0 3px ${
               error
-                ? 'rgba(var(--alert-color-rgb-components), 0.2)'
-                : 'var(--semi-transparent-accent-color)'
+                ? 'var(--color--feedback-fail--outline)'
+                : 'var(--color--focus--outline)'
             }`,
             '&:hover': {
-              borderColor: error ? 'var(--alert-color)' : 'var(--accent-color)',
+              borderColor: error
+                ? 'var(--color--feedback-fail--border)'
+                : 'var(--color--focus--border)',
             },
           };
         }
 
         return {
           ...result,
-          borderColor: error ? 'var(--alert-color)' : 'var(--border-color)',
-          backgroundColor: isDisabled ? 'var(--disabled-color)' : 'white',
+          borderColor: error
+            ? 'var(--color--feedback-fail--border)'
+            : 'var(--color--border)',
+          backgroundColor: isDisabled
+            ? 'var(--color--disabled--surface)'
+            : 'var(--color--surface)',
           '&:hover': {
             borderColor: error
-              ? 'var(--alert-color)'
-              : 'var(--darker-border-color)',
+              ? 'var(--color--feedback-fail--border)'
+              : 'var(--color--border-hover)',
           },
         };
       },
@@ -88,24 +98,35 @@ const useStyles = (isDisabled?: boolean, error?: boolean) => {
           ...provided,
           zIndex: 1000,
           minWidth: 250,
+          backgroundColor: 'var(--color--raised--surface)',
         };
       },
-      input: (provided) => {
-        const result = {
-          ...provided,
+      singleValue: (provided) => ({
+        ...provided,
+        color: 'var(--color--ink)',
+      }),
+      input: (provided) => ({
+        ...provided,
+        color: 'var(--color--ink)',
+        boxShadow: 'none',
+        'input:focus': {
           boxShadow: 'none',
-          'input:focus': {
-            boxShadow: 'none',
-          },
-        };
-
-        return result;
-      },
+        },
+      }),
+      option: (provided, { isFocused, isSelected }) => ({
+        ...provided,
+        backgroundColor: isSelected
+          ? 'var(--color--selected--surface)'
+          : isFocused
+            ? 'var(--color--surface-hover)'
+            : undefined,
+        color: 'var(--color--ink)',
+      }),
       multiValue: (provided) => {
         return {
           ...provided,
           zIndex: 100,
-          backgroundColor: 'var(--light-color)',
+          backgroundColor: 'var(--color--tinted--surface)',
           userSelect: 'none',
         };
       },

--- a/packages/react-ui/src/SelectInput/index.tsx
+++ b/packages/react-ui/src/SelectInput/index.tsx
@@ -61,7 +61,7 @@ const useStyles = (isDisabled?: boolean, error?: boolean) => {
             backgroundColor: isDisabled
               ? 'var(--color--disabled--surface)'
               : 'var(--color--surface)',
-            boxShadow: `0 0 0 3px ${
+            boxShadow: `0 0 0 4px ${
               error
                 ? 'var(--color--feedback-fail--outline)'
                 : 'var(--color--focus--outline)'

--- a/packages/react-ui/src/SidebarPanel/index.tsx
+++ b/packages/react-ui/src/SidebarPanel/index.tsx
@@ -1,32 +1,7 @@
 import classNames from 'classnames';
 import React, { type ReactNode, useState } from 'react';
+import { CaretDownIcon, CaretUpIcon } from '../icons';
 import s from './styles.module.css.json';
-
-function ChevronDownIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 448 512"
-      width="1em"
-      height="1em"
-    >
-      <path d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z" />
-    </svg>
-  );
-}
-
-function ChevronUpIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 448 512"
-      width="1em"
-      height="1em"
-    >
-      <path d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z" />
-    </svg>
-  );
-}
 
 export type SidebarPanelProps = {
   title?: ReactNode;
@@ -44,7 +19,7 @@ export type SidebarPanelProps = {
  *     <div
  *       style={{
  *         width: '300px',
- *         borderRight: '1px solid var(--border-color)',
+ *         borderRight: '1px solid var(--color--border)',
  *       }}
  *     >
  *       <SidebarPanel title="Default">Content</SidebarPanel>
@@ -61,7 +36,7 @@ export type SidebarPanelProps = {
  *         display: 'flex',
  *         justifyContent: 'center',
  *         alignItems: 'center',
- *         background: 'var(--light-bg-color)',
+ *         background: 'var(--color--surface-muted)',
  *       }}
  *     >
  *       Main content
@@ -92,7 +67,7 @@ export function SidebarPanel({
         >
           <div className={s.SidebarPanel__header__title}>{title}</div>
           <div className={s.SidebarPanel__header__chevron}>
-            {open ? <ChevronDownIcon /> : <ChevronUpIcon />}
+            {open ? <CaretDownIcon /> : <CaretUpIcon />}
           </div>
         </button>
       )}

--- a/packages/react-ui/src/SidebarPanel/styles.module.css
+++ b/packages/react-ui/src/SidebarPanel/styles.module.css
@@ -1,13 +1,13 @@
 .SidebarPanel {
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--color--border);
 }
 
 .SidebarPanel__header {
   font-family: inherit;
   cursor: pointer;
   line-height: inherit;
-  background-color: white;
-  color: var(--base-body-color);
+  background-color: var(--color--surface);
+  color: var(--color--ink);
   -webkit-appearance: none;
   -moz-appearance: none;
   font-size: inherit;
@@ -18,13 +18,13 @@
   width: 100%;
   display: flex;
   align-items: center;
-  background-color: var(--light-bg-color);
+  background-color: var(--color--surface-muted);
   user-select: none;
 }
 
 .SidebarPanel__header:hover,
 .SidebarPanel__header:focus {
-  background-color: var(--lighter-bg-color);
+  background-color: var(--color--surface-hover);
 }
 
 .SidebarPanel__header__title {
@@ -41,7 +41,6 @@
 
 .SidebarPanel__content {
   padding: 20px;
-  background-color: white;
 }
 
 .SidebarPanel__content--no-padding {

--- a/packages/react-ui/src/SidebarPanel/styles.module.css
+++ b/packages/react-ui/src/SidebarPanel/styles.module.css
@@ -1,13 +1,13 @@
 .SidebarPanel {
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--color--border);
 }
 
 .SidebarPanel__header {
   font-family: inherit;
   cursor: pointer;
   line-height: inherit;
-  background-color: white;
-  color: var(--base-body-color);
+  background-color: var(--color--surface);
+  color: var(--color--ink);
   -webkit-appearance: none;
   -moz-appearance: none;
   font-size: inherit;
@@ -18,13 +18,13 @@
   width: 100%;
   display: flex;
   align-items: center;
-  background-color: var(--light-bg-color);
+  background-color: var(--color--surface-muted);
   user-select: none;
 }
 
 .SidebarPanel__header:hover,
 .SidebarPanel__header:focus {
-  background-color: var(--lighter-bg-color);
+  background-color: var(--color--surface-hover);
 }
 
 .SidebarPanel__header__title {
@@ -41,7 +41,7 @@
 
 .SidebarPanel__content {
   padding: 20px;
-  background-color: white;
+  background-color: var(--color--surface);
 }
 
 .SidebarPanel__content--no-padding {

--- a/packages/react-ui/src/Spinner/styles.module.css
+++ b/packages/react-ui/src/Spinner/styles.module.css
@@ -12,7 +12,7 @@
 
 .Spinner__bar {
   animation: Spinner__spin 1.2s linear infinite;
-  background-color: var(--light-body-color);
+  background-color: var(--color--ink-subtle);
   position: absolute;
   width: 40%;
   height: 14%;

--- a/packages/react-ui/src/SplitView/SplitViewSash/styles.module.css
+++ b/packages/react-ui/src/SplitView/SplitViewSash/styles.module.css
@@ -3,7 +3,7 @@
   position: absolute;
   top: 0;
   transition: background-color 0.2s 0.15s;
-  background-color: rgba(var(--light-color-components), 0);
+  background-color: transparent;
   width: 100%;
   z-index: 2;
   display: flex;
@@ -13,7 +13,7 @@
 
 .SplitViewSash:hover,
 .SplitViewSash--dragging {
-  background-color: var(--light-color);
+  background-color: var(--color--tinted--surface);
 }
 
 .SplitViewSash:hover:has(.SplitViewSash__content:hover),
@@ -47,14 +47,14 @@
   width: 20px;
   height: 20px;
   border-radius: 6px;
-  border: 1px solid var(--border-color);
-  background: white;
+  border: 1px solid var(--color--border);
+  background: var(--color--surface);
   z-index: 2;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 10px;
-  color: var(--light-body-color);
+  color: var(--color--ink-subtle);
 }
 
 .SplitViewSash__content__button svg {
@@ -63,6 +63,6 @@
 }
 
 .SplitViewSash__content:hover .SplitViewSash__content__button {
-  background: var(--light-bg-color);
-  color: var(--base-body-color);
+  background: var(--color--surface-hover);
+  color: var(--color--ink);
 }

--- a/packages/react-ui/src/SplitView/SplitViewSash/styles.module.css
+++ b/packages/react-ui/src/SplitView/SplitViewSash/styles.module.css
@@ -13,7 +13,7 @@
 
 .SplitViewSash:hover,
 .SplitViewSash--dragging {
-  background-color: var(--color--tinted--surface);
+  background-color: var(--color--primary-soft--surface);
 }
 
 .SplitViewSash:hover:has(.SplitViewSash__content:hover),

--- a/packages/react-ui/src/SwitchField/styles.module.css
+++ b/packages/react-ui/src/SwitchField/styles.module.css
@@ -16,7 +16,7 @@
   -ms-user-select: text;
   user-select: text;
   margin-bottom: 0;
-  color: var(--base-body-color);
+  color: var(--color--ink);
 }
 
 .switchField__below {

--- a/packages/react-ui/src/SwitchInput/styles.module.css
+++ b/packages/react-ui/src/SwitchInput/styles.module.css
@@ -1,8 +1,9 @@
 .switchInput__inner {
-  color: #fff;
+  color: var(--color--primary--ink);
   font-size: 12px;
   position: absolute;
   left: 24px;
+  transition: left 0.3s cubic-bezier(0.35, 0, 0.25, 1);
 }
 
 .switchInput {
@@ -14,8 +15,8 @@
   line-height: 20px;
   vertical-align: middle;
   border-radius: 20px 20px;
-  border: 1px solid #ccc;
-  background-color: #ccc;
+  border: 1px solid var(--color--border);
+  background-color: var(--color--ink-muted);
   cursor: pointer;
   transition: all 0.3s cubic-bezier(0.35, 0, 0.25, 1);
 
@@ -26,18 +27,20 @@
     left: 2px;
     top: 1px;
     border-radius: 50% 50%;
-    background-color: #ffffff;
+    background-color: var(--color--surface);
     content: ' ';
     cursor: pointer;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.26);
+    box-shadow: var(--shadow--raised);
     transform: scale(1);
-    transition: left 0.3s cubic-bezier(0.35, 0, 0.25, 1);
+    transition:
+      left 0.3s cubic-bezier(0.35, 0, 0.25, 1),
+      transform 0.3s cubic-bezier(0.35, 0, 0.25, 1);
     animation-timing-function: cubic-bezier(0.35, 0, 0.25, 1);
     animation-duration: 0.3s;
     animation-name: switchInput__off;
   }
 
-  &:hover,
+  &:hover:after,
   &:focus:after {
     transform: scale(1.1);
     animation-name: switchInput__on;
@@ -45,8 +48,7 @@
 }
 
 .switchInput__checked {
-  border: 1px solid var(--accent-color);
-  background-color: var(--accent-color);
+  background-color: var(--color--primary--surface);
 
   .switchInput__inner {
     left: 6px;
@@ -59,16 +61,16 @@
 
 .switchInput__disabled {
   cursor: no-drop;
-  background: #ccc;
-  border-color: #ccc;
+  background: var(--color--disabled--surface);
+  border-color: var(--color--border);
 
   &:after {
-    background: #9e9e9e;
+    background: var(--color--disabled--ink);
     animation-name: none;
     cursor: no-drop;
   }
 
-  &:hover,
+  &:hover:after,
   &:focus:after {
     transform: scale(1);
     animation-name: none;

--- a/packages/react-ui/src/SwitchInput/styles.module.css
+++ b/packages/react-ui/src/SwitchInput/styles.module.css
@@ -1,8 +1,9 @@
 .switchInput__inner {
-  color: #fff;
+  color: var(--color--primary--ink);
   font-size: 12px;
   position: absolute;
   left: 24px;
+  transition: left 0.3s cubic-bezier(0.35, 0, 0.25, 1);
 }
 
 .switchInput {
@@ -14,8 +15,8 @@
   line-height: 20px;
   vertical-align: middle;
   border-radius: 20px 20px;
-  border: 1px solid #ccc;
-  background-color: #ccc;
+  border: 1px solid var(--color--border);
+  background-color: var(--color--ink-muted);
   cursor: pointer;
   transition: all 0.3s cubic-bezier(0.35, 0, 0.25, 1);
 
@@ -26,18 +27,20 @@
     left: 2px;
     top: 1px;
     border-radius: 50% 50%;
-    background-color: #ffffff;
+    background-color: var(--color--surface);
     content: ' ';
     cursor: pointer;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.26);
+    box-shadow: 0 2px 5px var(--color--shadow);
     transform: scale(1);
-    transition: left 0.3s cubic-bezier(0.35, 0, 0.25, 1);
+    transition:
+      left 0.3s cubic-bezier(0.35, 0, 0.25, 1),
+      transform 0.3s cubic-bezier(0.35, 0, 0.25, 1);
     animation-timing-function: cubic-bezier(0.35, 0, 0.25, 1);
     animation-duration: 0.3s;
     animation-name: switchInput__off;
   }
 
-  &:hover,
+  &:hover:after,
   &:focus:after {
     transform: scale(1.1);
     animation-name: switchInput__on;
@@ -45,8 +48,8 @@
 }
 
 .switchInput__checked {
-  border: 1px solid var(--accent-color);
-  background-color: var(--accent-color);
+  border: 1px solid var(--color--selected--border);
+  background-color: var(--color--primary--surface);
 
   .switchInput__inner {
     left: 6px;
@@ -59,16 +62,16 @@
 
 .switchInput__disabled {
   cursor: no-drop;
-  background: #ccc;
-  border-color: #ccc;
+  background: var(--color--disabled--surface);
+  border-color: var(--color--border);
 
   &:after {
-    background: #9e9e9e;
+    background: var(--color--disabled--ink);
     animation-name: none;
     cursor: no-drop;
   }
 
-  &:hover,
+  &:hover:after,
   &:focus:after {
     transform: scale(1);
     animation-name: none;

--- a/packages/react-ui/src/SwitchInput/styles.module.css
+++ b/packages/react-ui/src/SwitchInput/styles.module.css
@@ -49,6 +49,7 @@
 
 .switchInput__checked {
   background-color: var(--color--primary--surface);
+  border-color: var(--color--primary--surface);
 
   .switchInput__inner {
     left: 6px;

--- a/packages/react-ui/src/TextInput/styles.module.css
+++ b/packages/react-ui/src/TextInput/styles.module.css
@@ -3,27 +3,29 @@
   box-sizing: border-box;
   width: 100%;
   padding: 10px;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--color--border);
   appearance: none;
   border-radius: 0;
+  background-color: var(--color--surface);
   background-image: none;
   transition: border 0.2s var(--material-ease);
   font-size: var(--font-size-m);
   resize: none;
   font-family: inherit;
+  color: inherit;
 
   &::placeholder {
-    color: var(--placeholder-body-color);
+    color: var(--color--ink-placeholder);
   }
 
   &:hover {
-    border-color: var(--darker-border-color);
+    border-color: var(--color--border-hover);
   }
 
   &:focus {
     outline: 0;
-    border-color: var(--accent-color);
-    box-shadow: 0 0 0 3px var(--semi-transparent-accent-color);
+    border-color: var(--color--focus--border);
+    box-shadow: 0 0 0 3px var(--color--focus--outline);
   }
 }
 
@@ -33,20 +35,20 @@
 }
 
 .TextInput--disabled {
-  color: var(--light-body-color);
-  border-color: var(--border-color);
-  background: var(--lighter-bg-color);
+  color: var(--color--disabled--ink);
+  border-color: var(--color--border);
+  background: var(--color--disabled--surface);
 }
 
 .TextInput--error {
-  border-color: var(--alert-color);
+  border-color: var(--color--feedback-fail--border);
 
   &:hover,
   &:focus {
-    border-color: var(--alert-color);
+    border-color: var(--color--feedback-fail--border);
   }
 
   &:focus {
-    box-shadow: 0 0 0 3px rgba(var(--alert-color-rgb-components), 0.2);
+    box-shadow: 0 0 0 3px var(--color--feedback-fail--outline);
   }
 }

--- a/packages/react-ui/src/TextInput/styles.module.css
+++ b/packages/react-ui/src/TextInput/styles.module.css
@@ -41,14 +41,14 @@
 }
 
 .TextInput--error {
-  border-color: var(--color--feedback-fail--border);
+  border-color: var(--color--danger-soft--border);
 
   &:hover,
   &:focus {
-    border-color: var(--color--feedback-fail--border);
+    border-color: var(--color--danger-soft--border);
   }
 
   &:focus {
-    box-shadow: 0 0 0 4px var(--color--feedback-fail--outline);
+    box-shadow: 0 0 0 4px var(--color--danger-soft--outline);
   }
 }

--- a/packages/react-ui/src/TextInput/styles.module.css
+++ b/packages/react-ui/src/TextInput/styles.module.css
@@ -25,7 +25,7 @@
   &:focus {
     outline: 0;
     border-color: var(--color--focus--border);
-    box-shadow: 0 0 0 3px var(--color--focus--outline);
+    box-shadow: 0 0 0 4px var(--color--focus--outline);
   }
 }
 
@@ -49,6 +49,6 @@
   }
 
   &:focus {
-    box-shadow: 0 0 0 3px var(--color--feedback-fail--outline);
+    box-shadow: 0 0 0 4px var(--color--feedback-fail--outline);
   }
 }

--- a/packages/react-ui/src/TextareaInput/styles.module.css
+++ b/packages/react-ui/src/TextareaInput/styles.module.css
@@ -41,14 +41,14 @@
 }
 
 .TextareaInput--error {
-  border-color: var(--color--feedback-fail--border);
+  border-color: var(--color--danger-soft--border);
 
   &:hover,
   &:focus {
-    border-color: var(--color--feedback-fail--border);
+    border-color: var(--color--danger-soft--border);
   }
 
   &:focus {
-    box-shadow: 0 0 0 4px var(--color--feedback-fail--outline);
+    box-shadow: 0 0 0 4px var(--color--danger-soft--outline);
   }
 }

--- a/packages/react-ui/src/TextareaInput/styles.module.css
+++ b/packages/react-ui/src/TextareaInput/styles.module.css
@@ -3,27 +3,29 @@
   box-sizing: border-box;
   width: 100%;
   padding: 10px;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--color--border);
   appearance: none;
   border-radius: 0;
+  background-color: var(--color--surface);
   background-image: none;
   transition: border 0.2s var(--material-ease);
   font-size: var(--font-size-m);
   resize: none;
   font-family: inherit;
+  color: inherit;
 
   &::placeholder {
-    color: var(--placeholder-body-color);
+    color: var(--color--ink-placeholder);
   }
 
   &:hover {
-    border-color: var(--darker-border-color);
+    border-color: var(--color--border-hover);
   }
 
   &:focus {
     outline: 0;
-    border-color: var(--accent-color);
-    box-shadow: 0 0 0 3px var(--semi-transparent-accent-color);
+    border-color: var(--color--focus--border);
+    box-shadow: 0 0 0 3px var(--color--focus--outline);
   }
 }
 
@@ -33,20 +35,20 @@
 }
 
 .TextareaInput--disabled {
-  color: var(--light-body-color);
-  border-color: var(--border-color);
-  background: var(--lighter-bg-color);
+  color: var(--color--disabled--ink);
+  border-color: var(--color--border);
+  background: var(--color--disabled--surface);
 }
 
 .TextareaInput--error {
-  border-color: var(--alert-color);
+  border-color: var(--color--feedback-fail--border);
 
   &:hover,
   &:focus {
-    border-color: var(--alert-color);
+    border-color: var(--color--feedback-fail--border);
   }
 
   &:focus {
-    box-shadow: 0 0 0 3px rgba(var(--alert-color-rgb-components), 0.2);
+    box-shadow: 0 0 0 3px var(--color--feedback-fail--outline);
   }
 }

--- a/packages/react-ui/src/TextareaInput/styles.module.css
+++ b/packages/react-ui/src/TextareaInput/styles.module.css
@@ -25,7 +25,7 @@
   &:focus {
     outline: 0;
     border-color: var(--color--focus--border);
-    box-shadow: 0 0 0 3px var(--color--focus--outline);
+    box-shadow: 0 0 0 4px var(--color--focus--outline);
   }
 }
 
@@ -49,6 +49,6 @@
   }
 
   &:focus {
-    box-shadow: 0 0 0 3px var(--color--feedback-fail--outline);
+    box-shadow: 0 0 0 4px var(--color--feedback-fail--outline);
   }
 }

--- a/packages/react-ui/src/Toolbar/Button/styles.module.css
+++ b/packages/react-ui/src/Toolbar/Button/styles.module.css
@@ -3,7 +3,7 @@
   cursor: pointer;
   line-height: inherit;
   background-color: transparent;
-  color: var(--base-body-color);
+  color: var(--color--ink);
   -webkit-appearance: none;
   -moz-appearance: none;
   box-sizing: border-box;
@@ -14,13 +14,13 @@
   justify-content: center;
   width: 49px;
   min-height: 49px;
-  border-left: 1px solid var(--border-color);
-  border-right: 1px solid var(--border-color);
+  border-left: 1px solid var(--color--border);
+  border-right: 1px solid var(--color--border);
 }
 
 .Button:hover,
 .Button:focus {
-  background-color: var(--light-bg-color);
+  background-color: var(--color--surface-hover);
 }
 
 .Button:first-child {

--- a/packages/react-ui/src/Toolbar/Toolbar/index.tsx
+++ b/packages/react-ui/src/Toolbar/Toolbar/index.tsx
@@ -23,7 +23,7 @@ export type ToolbarProps = {
  *       display: 'flex',
  *       justifyContent: 'center',
  *       alignItems: 'center',
- *       background: 'var(--light-bg-color)',
+ *       background: 'var(--color--surface-muted)',
  *       height: '150px',
  *     }}
  *   >
@@ -54,7 +54,7 @@ export type ToolbarProps = {
  *       display: 'flex',
  *       justifyContent: 'center',
  *       alignItems: 'center',
- *       background: 'var(--light-bg-color)',
+ *       background: 'var(--color--surface-muted)',
  *       height: '150px',
  *     }}
  *   >
@@ -83,7 +83,7 @@ export type ToolbarProps = {
  *       display: 'flex',
  *       justifyContent: 'center',
  *       alignItems: 'center',
- *       background: 'var(--light-bg-color)',
+ *       background: 'var(--color--surface-muted)',
  *       height: '150px',
  *     }}
  *   >

--- a/packages/react-ui/src/Toolbar/Toolbar/styles.module.css
+++ b/packages/react-ui/src/Toolbar/Toolbar/styles.module.css
@@ -1,7 +1,7 @@
 .Toolbar {
   display: flex;
-  border-bottom: 1px solid var(--border-color);
-  border-top: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--color--border);
+  border-top: 1px solid var(--color--border);
   align-items: stretch;
   position: relative;
 }

--- a/packages/react-ui/src/Tooltip/TooltipContent/styles.module.css
+++ b/packages/react-ui/src/Tooltip/TooltipContent/styles.module.css
@@ -1,7 +1,8 @@
 .tooltip {
   padding: 10px 15px;
-  box-shadow: var(--shadow--raised);
-  background: var(--color--raised--surface);
+  color: var(--color--tooltip--ink);
+  box-shadow: var(--shadow--floating);
+  background: var(--color--tooltip--surface);
   border-radius: 4px;
   max-width: 400px;
   word-wrap: break-word;

--- a/packages/react-ui/src/Tooltip/TooltipContent/styles.module.css
+++ b/packages/react-ui/src/Tooltip/TooltipContent/styles.module.css
@@ -1,7 +1,7 @@
 .tooltip {
   padding: 10px 15px;
-  box-shadow: 0 1px 9px rgba(0, 0, 0, 0.2);
-  background: white;
+  box-shadow: 0 1px 9px var(--color--shadow);
+  background: var(--color--raised--surface);
   border-radius: 4px;
   max-width: 400px;
   word-wrap: break-word;

--- a/packages/react-ui/src/Tooltip/TooltipContent/styles.module.css
+++ b/packages/react-ui/src/Tooltip/TooltipContent/styles.module.css
@@ -1,7 +1,7 @@
 .tooltip {
   padding: 10px 15px;
-  box-shadow: 0 1px 9px rgba(0, 0, 0, 0.2);
-  background: white;
+  box-shadow: var(--shadow--raised);
+  background: var(--color--raised--surface);
   border-radius: 4px;
   max-width: 400px;
   word-wrap: break-word;

--- a/packages/react-ui/src/Tooltip/TooltipDelayGroup/index.tsx
+++ b/packages/react-ui/src/Tooltip/TooltipDelayGroup/index.tsx
@@ -87,8 +87,8 @@ export type TooltipDelayGroupProps = {
  *       display: 'flex',
  *       gap: 'var(--spacing-xs)',
  *       padding: 'var(--spacing-s)',
- *       borderRadius: 'var(--border-radius-m)',
- *       backgroundColor: 'var(--light-bg-color)'
+ *       borderRadius: '4px',
+ *       backgroundColor: 'var(--color--surface-muted)'
  *     }}>
  *       <Tooltip>
  *         <TooltipTrigger>

--- a/packages/react-ui/src/VerticalSplit/index.tsx
+++ b/packages/react-ui/src/VerticalSplit/index.tsx
@@ -61,7 +61,7 @@ function calculateSizes({
  *           Main content
  *         </div>
  *       </div>
- *       <div style={{ display: 'flex', flexDirection: 'column', height: '100%', borderLeft: '1px solid var(--border-color)' }}>
+ *       <div style={{ display: 'flex', flexDirection: 'column', height: '100%', borderLeft: '1px solid var(--color--border)' }}>
  *         <Toolbar>
  *           <ToolbarStack stackSize="l">
  *             <ToolbarTitle>Secondary</ToolbarTitle>
@@ -108,7 +108,7 @@ function calculateSizes({
  *           Sidebar
  *         </div>
  *       </div>
- *       <div style={{ display: 'flex', flexDirection: 'column', height: '100%', borderLeft: '1px solid var(--border-color)' }}>
+ *       <div style={{ display: 'flex', flexDirection: 'column', height: '100%', borderLeft: '1px solid var(--color--border)' }}>
  *         <Toolbar>
  *           <ToolbarStack stackSize="l">
  *             <ToolbarTitle>Primary</ToolbarTitle>
@@ -168,7 +168,7 @@ function calculateSizes({
  *                display: 'flex',
  *                flexDirection: 'column',
  *                height: '100%',
- *                borderLeft: '1px solid var(--border-color)',
+ *                borderLeft: '1px solid var(--color--border)',
  *              }}
  *            >
  *              <Toolbar>
@@ -233,7 +233,7 @@ function calculateSizes({
  *                display: 'flex',
  *                flexDirection: 'column',
  *                height: '100%',
- *                borderLeft: '1px solid var(--border-color)',
+ *                borderLeft: '1px solid var(--color--border)',
  *              }}
  *            >
  *              <Toolbar>

--- a/packages/react-ui/src/VerticalSplit/styles.module.css
+++ b/packages/react-ui/src/VerticalSplit/styles.module.css
@@ -1,6 +1,6 @@
 .VerticalSplitPane__expand {
   transition: all 0.3s cubic-bezier(0.55, 0, 0.1, 1);
-  background: white;
+  background: var(--color--surface);
   cursor: pointer;
   position: absolute;
   top: 0;
@@ -10,12 +10,12 @@
 }
 
 .VerticalSplitPane__expand:hover {
-  background: var(--light-bg-color);
+  background: var(--color--surface-hover);
   animation: VerticalSplitPane__expand 0.6s cubic-bezier(0.55, 0, 0.1, 1);
 }
 
 .VerticalSplitPane__expand.VerticalSplitPane__expand {
-  border-right: 1px solid var(--border-color);
+  border-right: 1px solid var(--color--border);
   transform-origin: left;
 }
 
@@ -23,7 +23,7 @@
 }
 
 .VerticalSplitPane__expand.VerticalSplitPane__expand--right {
-  border-left: 1px solid var(--border-color);
+  border-left: 1px solid var(--color--border);
   transform-origin: right;
 }
 
@@ -45,11 +45,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: linear-gradient(
-    to bottom,
-    rgba(48, 48, 47, 0.5),
-    rgba(48, 48, 47, 0.3)
-  );
+  background: var(--color--overlay--surface);
   z-index: 12;
   height: 100%;
   overflow: hidden;
@@ -76,8 +72,8 @@
   position: absolute;
   top: 0;
   bottom: 0;
-  background: white;
-  box-shadow: 0 0 15px rgba(0, 0, 0, 0.4);
+  background: var(--color--surface);
+  box-shadow: 0 0 15px var(--color--shadow-strong);
 }
 
 .VerticalSplitPaneOverlay__secondary--left {

--- a/packages/react-ui/src/VerticalSplit/styles.module.css
+++ b/packages/react-ui/src/VerticalSplit/styles.module.css
@@ -1,6 +1,6 @@
 .VerticalSplitPane__expand {
   transition: all 0.3s cubic-bezier(0.55, 0, 0.1, 1);
-  background: white;
+  background: var(--color--surface);
   cursor: pointer;
   position: absolute;
   top: 0;
@@ -10,12 +10,12 @@
 }
 
 .VerticalSplitPane__expand:hover {
-  background: var(--light-bg-color);
+  background: var(--color--surface-hover);
   animation: VerticalSplitPane__expand 0.6s cubic-bezier(0.55, 0, 0.1, 1);
 }
 
 .VerticalSplitPane__expand.VerticalSplitPane__expand {
-  border-right: 1px solid var(--border-color);
+  border-right: 1px solid var(--color--border);
   transform-origin: left;
 }
 
@@ -23,7 +23,7 @@
 }
 
 .VerticalSplitPane__expand.VerticalSplitPane__expand--right {
-  border-left: 1px solid var(--border-color);
+  border-left: 1px solid var(--color--border);
   transform-origin: right;
 }
 
@@ -45,11 +45,8 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: linear-gradient(
-    to bottom,
-    rgba(48, 48, 47, 0.5),
-    rgba(48, 48, 47, 0.3)
-  );
+  background: var(--color--backdrop--surface);
+  backdrop-filter: blur(4px);
   z-index: 12;
   height: 100%;
   overflow: hidden;
@@ -76,8 +73,8 @@
   position: absolute;
   top: 0;
   bottom: 0;
-  background: white;
-  box-shadow: 0 0 15px rgba(0, 0, 0, 0.4);
+  background: var(--color--surface);
+  box-shadow: var(--shadow--ambient);
 }
 
 .VerticalSplitPaneOverlay__secondary--left {

--- a/packages/react-ui/src/base.css
+++ b/packages/react-ui/src/base.css
@@ -87,3 +87,20 @@ body {
   padding: 0;
   margin: 0;
 }
+
+/**
+ * Theme the page-level (viewport) scrollbar to match the canvas.
+ *
+ * `html`/`body` live outside the `Canvas` wrapper, so they don't inherit the
+ * canvas color variables. The `Canvas` component mirrors the
+ * `--color--scrollbar--fill` token onto `document.documentElement` (see
+ * `Canvas/index.tsx`) so this rule can resolve it. `scrollbar-color` is
+ * inherited, so this also covers `body` and anything scrolling at the page
+ * level. Kept in a layer so a plugin developer's own unlayered
+ * `scrollbar-color` rule always wins, regardless of specificity.
+ */
+@layer datocms-react-ui {
+  html {
+    scrollbar-color: var(--color--scrollbar--fill) transparent;
+  }
+}

--- a/packages/react-ui/src/generateStyleFromCtx/index.ts
+++ b/packages/react-ui/src/generateStyleFromCtx/index.ts
@@ -27,7 +27,7 @@ export function generateStyleFromCtx(
       ]),
     ),
     // Semantic color tokens arrive keyed by their final CSS custom property
-    // name (e.g. `--color--raised--surface`), so they're applied verbatim. The
+    // name (e.g. `--color--surface-raised`), so they're applied verbatim. The
     // SDK stays agnostic of the token vocabulary: whatever the host sends ends
     // up on the canvas, and plugin CSS references it with `var(--…)`.
     ...ctx.semanticColorTokensTheme,

--- a/packages/react-ui/src/generateStyleFromCtx/index.ts
+++ b/packages/react-ui/src/generateStyleFromCtx/index.ts
@@ -30,6 +30,6 @@ export function generateStyleFromCtx(
     // name (e.g. `--color--surface-raised`), so they're applied verbatim. The
     // SDK stays agnostic of the token vocabulary: whatever the host sends ends
     // up on the canvas, and plugin CSS references it with `var(--…)`.
-    ...ctx.semanticColorTokensTheme,
+    ...ctx.cssDesignTokens,
   };
 }

--- a/packages/react-ui/src/generateStyleFromCtx/index.ts
+++ b/packages/react-ui/src/generateStyleFromCtx/index.ts
@@ -8,6 +8,151 @@ function camelToDash(str: string) {
   return str.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
 }
 
+/**
+ * Maps camelCase semantic token keys to their CSS custom property names
+ * (without the `--` prefix). The CSS names preserve the double-dash
+ * namespace separators used by the host application.
+ */
+const semanticTokenCssNames: Record<string, string> = {
+  /* --- Standalone --- */
+  colorSurface: 'color--surface',
+  colorSurfaceHover: 'color--surface-hover',
+  colorSurfaceMuted: 'color--surface-muted',
+  colorInk: 'color--ink',
+  colorInkSubtle: 'color--ink-subtle',
+  colorInkHover: 'color--ink-hover',
+  colorInkMuted: 'color--ink-muted',
+  colorInkPlaceholder: 'color--ink-placeholder',
+  colorInkPrimary: 'color--ink-primary',
+  colorInkAccent: 'color--ink-accent',
+  colorInkDisabled: 'color--ink-disabled',
+  colorBorder: 'color--border',
+  colorBorderHover: 'color--border-hover',
+
+  /* --- Context: raised --- */
+  colorRaisedSurface: 'color--raised--surface',
+  colorRaisedSurfaceHover: 'color--raised--surface-hover',
+  colorRaisedSurfaceActive: 'color--raised--surface-active',
+
+  /* --- Context: primary --- */
+  colorPrimarySurface: 'color--primary--surface',
+  colorPrimarySurfaceHover: 'color--primary--surface-hover',
+  colorPrimarySurfaceActive: 'color--primary--surface-active',
+  colorPrimarySurfaceMuted: 'color--primary--surface-muted',
+  colorPrimaryInk: 'color--primary--ink',
+  colorPrimaryBorder: 'color--primary--border',
+
+  /* --- Context: tinted --- */
+  colorTintedSurface: 'color--tinted--surface',
+  colorTintedSurfaceHover: 'color--tinted--surface-hover',
+  colorTintedSurfaceActive: 'color--tinted--surface-active',
+  colorTintedInk: 'color--tinted--ink',
+
+  /* --- Context: accent --- */
+  colorAccentSurface: 'color--accent--surface',
+  colorAccentInk: 'color--accent--ink',
+
+  /* --- Context: selected --- */
+  colorSelectedSurface: 'color--selected--surface',
+  colorSelectedInk: 'color--selected--ink',
+  colorSelectedBorder: 'color--selected--border',
+
+  /* --- Context: disabled --- */
+  colorDisabledSurface: 'color--disabled--surface',
+  colorDisabledInk: 'color--disabled--ink',
+
+  /* --- Context: danger --- */
+  colorDangerSurface: 'color--danger--surface',
+  colorDangerInk: 'color--danger--ink',
+
+  /* --- Context: enterprise --- */
+  colorEnterpriseSurface: 'color--enterprise--surface',
+
+  /* --- Context: focus --- */
+  colorFocusBorder: 'color--focus--border',
+  colorFocusOutline: 'color--focus--outline',
+
+  /* --- Feedback --- */
+  colorFeedbackFailInk: 'color--feedback-fail--ink',
+  colorFeedbackFailBorder: 'color--feedback-fail--border',
+  colorFeedbackFailOutline: 'color--feedback-fail--outline',
+  colorFeedbackWarningInk: 'color--feedback-warning--ink',
+  colorFeedbackWarningSurface: 'color--feedback-warning--surface',
+  colorFeedbackSuccessInk: 'color--feedback-success--ink',
+  colorFeedbackWarningBorder: 'color--feedback-warning--border',
+  colorFeedbackSuccessBorder: 'color--feedback-success--border',
+
+  /* --- Context: highlight --- */
+  colorHighlightSurface: 'color--highlight--surface',
+
+  /* --- Diffs --- */
+  colorDiffAddedSurface: 'color--diff-added--surface',
+  colorDiffRemovedSurface: 'color--diff-removed--surface',
+  colorDiffChangedSurface: 'color--diff-changed--surface',
+  colorDiffAddedSurfaceSubtle: 'color--diff-added--surface-subtle',
+  colorDiffRemovedSurfaceSubtle: 'color--diff-removed--surface-subtle',
+  colorDiffChangedSurfaceSubtle: 'color--diff-changed--surface-subtle',
+  colorDiffAddedOutlineSubtle: 'color--diff-added--outline-subtle',
+  colorDiffRemovedOutlineSubtle: 'color--diff-removed--outline-subtle',
+  colorDiffChangedOutlineSubtle: 'color--diff-changed--outline-subtle',
+  colorDiffChangedBorder: 'color--diff-changed--border',
+  colorDiffChangedBorderNegative: 'color--diff-changed--border-negative',
+
+  /* --- Status --- */
+  colorStatusDraftInk: 'color--status-draft--ink',
+  colorStatusOutdatedInk: 'color--status-outdated--ink',
+  colorStatusPublishedInk: 'color--status-published--ink',
+
+  /* --- Backdrop --- */
+  colorBackdropSurface: 'color--backdrop--surface',
+  colorBackdropInk: 'color--backdrop--ink',
+
+  /* --- Overlay --- */
+  colorOverlaySurface: 'color--overlay--surface',
+  colorOverlaySurfaceSubtle: 'color--overlay--surface-subtle',
+  colorOverlayInk: 'color--overlay--ink',
+
+  /* --- Stacked --- */
+  colorStackedSurfaceBase: 'color--stacked--surface-base',
+  colorStackedSurface: 'color--stacked--surface',
+  colorStackedSurfaceRaised: 'color--stacked--surface-raised',
+  colorStackedInk: 'color--stacked--ink',
+  colorStackedInkSubtle: 'color--stacked--ink-subtle',
+  colorStackedBorder: 'color--stacked--border',
+  colorStackedSurfaceHover: 'color--stacked--surface-hover',
+  colorStackedSurfaceTranslucent: 'color--stacked--surface-translucent',
+  colorStackedSurfaceButton: 'color--stacked--surface-button',
+  colorStackedSurfaceButtonActive: 'color--stacked--surface-button-active',
+
+  /* --- Progress --- */
+  colorProgressTrack: 'color--progress--track',
+  colorProgressFill: 'color--progress--fill',
+  colorProgressFillHover: 'color--progress--fill-hover',
+
+  /* --- Tooltip --- */
+  colorTooltipSurface: 'color--tooltip--surface',
+  colorTooltipSurfaceHover: 'color--tooltip--surface-hover',
+  colorTooltipInk: 'color--tooltip--ink',
+  colorTooltipInkSubtle: 'color--tooltip--ink-subtle',
+
+  /* --- Code --- */
+  colorCodeSurface: 'color--code--surface',
+  colorCodeInk: 'color--code--ink',
+
+  /* --- Shadows --- */
+  colorShadowSubtle: 'color--shadow-subtle',
+  colorShadow: 'color--shadow',
+  colorShadowStrong: 'color--shadow-strong',
+
+  /* --- Scrollbar --- */
+  colorScrollbar: 'color--scrollbar',
+
+  /* --- Shadow composites --- */
+  shadowElevated: 'shadow--elevated',
+  shadowFloat: 'shadow--float',
+  shadowAmbient: 'shadow--ambient',
+};
+
 export function generateStyleFromCtx(
   ctx: BaseCtx,
   noBodyPadding = false,
@@ -25,5 +170,13 @@ export function generateStyleFromCtx(
         ],
       ]),
     ),
+    ...(ctx.semanticColorTokensTheme
+      ? Object.fromEntries(
+          Object.entries(ctx.semanticColorTokensTheme).map(([k, v]) => [
+            `--${semanticTokenCssNames[k] ?? camelToDash(k)}`,
+            v,
+          ]),
+        )
+      : undefined),
   };
 }

--- a/packages/react-ui/src/generateStyleFromCtx/index.ts
+++ b/packages/react-ui/src/generateStyleFromCtx/index.ts
@@ -1,5 +1,5 @@
 import type { CSSProperties } from 'react';
-import { BaseCtx } from '../Canvas';
+import type { BaseCtx } from '../Canvas';
 
 function camelToDash(str: string) {
   if (str === str.toLowerCase()) {
@@ -16,6 +16,7 @@ export function generateStyleFromCtx(
     padding: noBodyPadding
       ? undefined
       : ctx.bodyPadding.map((p) => `${p}px`).join(' '),
+    // Legacy, deprecated color tokens
     ...Object.fromEntries(
       Object.entries(ctx.theme).flatMap(([k, v]) => [
         [`--${camelToDash(k)}`, v],
@@ -25,5 +26,10 @@ export function generateStyleFromCtx(
         ],
       ]),
     ),
+    // Semantic color tokens arrive keyed by their final CSS custom property
+    // name (e.g. `--color--raised--surface`), so they're applied verbatim. The
+    // SDK stays agnostic of the token vocabulary: whatever the host sends ends
+    // up on the canvas, and plugin CSS references it with `var(--…)`.
+    ...ctx.semanticColorTokensTheme,
   };
 }

--- a/packages/react-ui/src/icons.tsx
+++ b/packages/react-ui/src/icons.tsx
@@ -16,6 +16,7 @@ export function BackIcon({
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
       viewBox="0 0 256 512"
       width={width}
       height={height}
@@ -36,6 +37,7 @@ export function SidebarLeftArrowIcon({
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
       viewBox="0 0 448 512"
       width={width}
       height={height}
@@ -56,6 +58,7 @@ export function SidebarRightArrowIcon({
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
       viewBox="0 0 448 512"
       width={width}
       height={height}
@@ -76,6 +79,7 @@ export function CaretDownIcon({
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
       viewBox="0 0 320 512"
       width={width}
       height={height}
@@ -96,6 +100,7 @@ export function CaretUpIcon({
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
       viewBox="0 0 320 512"
       width={width}
       height={height}
@@ -116,6 +121,7 @@ export function ChevronsLeftIcon({
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
       viewBox="0 0 512 512"
       width={width}
       height={height}
@@ -136,6 +142,7 @@ export function ChevronsRightIcon({
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
       viewBox="0 0 512 512"
       width={width}
       height={height}
@@ -156,6 +163,7 @@ export function SidebarFlipIcon({
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
       viewBox="0 0 512 512"
       width={width}
       height={height}

--- a/packages/sdk/UPGRADING.md
+++ b/packages/sdk/UPGRADING.md
@@ -1,14 +1,14 @@
 # Upgrading datocms-plugin-sdk
 
-## v3.0.0 — Semantic color tokens
+## v2.2.0 — Semantic color tokens
 
-The plugin context now exposes a `semanticColorTokensTheme` field with the
+The plugin context now exposes a `cssDesignTokens` field with the
 active color palette for the current DatoCMS host. This is the new source
 of truth for plugin theming and supports dark mode.
 
 ### What's new
 
-- `ctx.semanticColorTokensTheme` — a `Record<string, string>` mapping CSS
+- `ctx.cssDesignTokens` — a `Record<string, string>` mapping CSS
   custom property names to their resolved values (e.g.
   `{ '--color--surface': '…', '--color--primary--surface': '…' }`). The host
   computes these for the user's **active theme**, light or dark per the
@@ -16,7 +16,7 @@ of truth for plugin theming and supports dark mode.
   keeps no token list of its own, so the vocabulary can evolve host-side
   without an SDK release. If you use `datocms-react-ui`, `Canvas` injects
   these onto the canvas for you; otherwise apply them yourself, e.g.
-  `Object.assign(document.documentElement.style, ctx.semanticColorTokensTheme)`.
+  `Object.assign(document.documentElement.style, ctx.cssDesignTokens)`.
 - `ctx.theme` — still present and unchanged in shape, but **deprecated**.
   The host now pins this field to **light-mode values only**, regardless
   of the user's active theme, so existing plugins that read it (or use
@@ -48,7 +48,7 @@ of truth for plugin theming and supports dark mode.
 [light-dark]: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark
 
 > **Host contract.** `ctx.theme` always returns light-mode colors;
-> `ctx.semanticColorTokensTheme` is theme-aware. This lets plugins upgrade
+> `ctx.cssDesignTokens` is theme-aware. This lets plugins upgrade
 > to the latest version without breaking, and opt into the active theme by
 > reading the new field.
 
@@ -59,5 +59,5 @@ If your plugin uses `datocms-react-ui`, see
 changes are there, including the dark-mode audit checklist.
 
 If your plugin reads `ctx.theme` directly, you can keep doing so for now.
-Migrating to `ctx.semanticColorTokensTheme` will let your plugin follow
+Migrating to `ctx.cssDesignTokens` will let your plugin follow
 the user's active theme (including dark mode).

--- a/packages/sdk/UPGRADING.md
+++ b/packages/sdk/UPGRADING.md
@@ -1,0 +1,52 @@
+# Upgrading datocms-plugin-sdk
+
+## v3.0.0 — Semantic color tokens
+
+The plugin context now exposes a `semanticColorTokensTheme` field with the
+active color palette for the current DatoCMS host. This is the new source
+of truth for plugin theming and supports dark mode.
+
+### What's new
+
+- `ctx.semanticColorTokensTheme` — a `Record<string, string>` mapping CSS
+  custom property names to their resolved values (e.g.
+  `{ '--color--surface': '…', '--color--primary--surface': '…' }`). The host
+  computes these for the user's **active theme**, light or dark per the
+  user's preference. The SDK applies whatever the host sends verbatim and
+  keeps no token list of its own, so the vocabulary can evolve host-side
+  without an SDK release. If you use `datocms-react-ui`, `Canvas` injects
+  these onto the canvas for you; otherwise apply them yourself, e.g.
+  `Object.assign(document.documentElement.style, ctx.semanticColorTokensTheme)`.
+- `ctx.theme` — still present and unchanged in shape, but **deprecated**.
+  The host now pins this field to **light-mode values only**, regardless
+  of the user's active theme, so existing plugins that read it (or use
+  the `--accent-color` / `--light-color` / `--primary-color` /
+  `--dark-color` / `--semi-transparent-accent-color` CSS vars derived
+  from it) keep rendering exactly as they did before.
+- `ctx.colorScheme` — `'light'` or `'dark'`. The host has already resolved
+  `'system'` for you. The SDK runtime also writes
+  `document.documentElement.dataset.theme` to `"light"` / `"dark"` on
+  initial handshake and on every ctx update, so you can theme with CSS
+  selectors like:
+
+  ```css
+  [data-theme="dark"] .my-panel { background: #222; }
+  ```
+
+  For non-CSS decisions (picking a logo asset, a syntax-highlighting
+  preset, …) branch on `ctx.colorScheme` directly.
+
+> **Host contract.** `ctx.theme` always returns light-mode colors;
+> `ctx.semanticColorTokensTheme` is theme-aware. This lets plugins upgrade
+> to the latest version without breaking, and opt into the active theme by
+> reading the new field.
+
+### Action required
+
+If your plugin uses `datocms-react-ui`, see
+[its upgrade notes](../react-ui/UPGRADING.md) — most of the visible
+changes are there, including the dark-mode audit checklist.
+
+If your plugin reads `ctx.theme` directly, you can keep doing so for now.
+Migrating to `ctx.semanticColorTokensTheme` will let your plugin follow
+the user's active theme (including dark mode).

--- a/packages/sdk/UPGRADING.md
+++ b/packages/sdk/UPGRADING.md
@@ -18,6 +18,18 @@ of truth for plugin theming and supports dark mode.
   the `--accent-color` / `--light-color` / `--primary-color` /
   `--dark-color` / `--semi-transparent-accent-color` CSS vars derived
   from it) keep rendering exactly as they did before.
+- `ctx.colorScheme` — `'light'` or `'dark'`. The host has already resolved
+  `'system'` for you. The SDK runtime also writes
+  `document.documentElement.dataset.theme` to `"light"` / `"dark"` on
+  initial handshake and on every ctx update, so you can theme with CSS
+  selectors like:
+
+  ```css
+  [data-theme="dark"] .my-panel { background: #222; }
+  ```
+
+  For non-CSS decisions (picking a logo asset, a syntax-highlighting
+  preset, …) branch on `ctx.colorScheme` directly.
 
 > **Host contract.** `ctx.theme` is light-only; `ctx.semanticColorTokensTheme`
 > is theme-aware. This split keeps existing plugins safe by construction

--- a/packages/sdk/UPGRADING.md
+++ b/packages/sdk/UPGRADING.md
@@ -24,17 +24,28 @@ of truth for plugin theming and supports dark mode.
   `--dark-color` / `--semi-transparent-accent-color` CSS vars derived
   from it) keep rendering exactly as they did before.
 - `ctx.colorScheme` — `'light'` or `'dark'`. The host has already resolved
-  `'system'` for you. The SDK runtime also writes
-  `document.documentElement.dataset.colorScheme` to `"light"` / `"dark"`
-  on initial handshake and on every ctx update, so you can theme with CSS
-  selectors like:
+  `'system'` for you. On initial handshake and on every ctx update, the SDK
+  runtime reflects this onto `document.documentElement` two ways:
 
-  ```css
-  [data-color-scheme="dark"] .my-panel { background: #222; }
-  ```
+  - the `data-color-scheme="light"` / `data-color-scheme="dark"` attribute,
+    so you can theme with explicit CSS selectors:
+
+    ```css
+    [data-color-scheme="dark"] .my-panel { background: #222; }
+    ```
+
+  - the actual `color-scheme` CSS property, so [`light-dark()`][light-dark]
+    resolves to the correct branch (and native form controls / scrollbars
+    match the active scheme) anywhere in your plugin frame:
+
+    ```css
+    .my-panel { background: light-dark(#fff, #222); }
+    ```
 
   For non-CSS decisions (picking a logo asset, a syntax-highlighting
   preset, …) branch on `ctx.colorScheme` directly.
+
+[light-dark]: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark
 
 > **Host contract.** `ctx.theme` always returns light-mode colors;
 > `ctx.semanticColorTokensTheme` is theme-aware. This lets plugins upgrade

--- a/packages/sdk/UPGRADING.md
+++ b/packages/sdk/UPGRADING.md
@@ -10,10 +10,19 @@ of truth for plugin theming and supports dark mode.
 
 - `ctx.semanticColorTokensTheme` — a record of semantic color token values
   (e.g. `colorSurface`, `colorInk`, `colorPrimarySurface`, …). The host
-  computes these for the user's active theme, including dark mode.
+  computes these for the user's **active theme**, light or dark per the
+  user's preference.
 - `ctx.theme` — still present and unchanged in shape, but **deprecated**.
-  Kept for backward compatibility with third-party plugins that read it
-  directly.
+  The host now pins this field to **light-mode values only**, regardless
+  of the user's active theme, so existing plugins that read it (or use
+  the `--accent-color` / `--light-color` / `--primary-color` /
+  `--dark-color` / `--semi-transparent-accent-color` CSS vars derived
+  from it) keep rendering exactly as they did before.
+
+> **Host contract.** `ctx.theme` is light-only; `ctx.semanticColorTokensTheme`
+> is theme-aware. This split keeps existing plugins safe by construction
+> — no v2 plugin can stumble into dark mode — while letting v3 plugins
+> opt into the active theme by reading the new field.
 
 ### Action required
 

--- a/packages/sdk/UPGRADING.md
+++ b/packages/sdk/UPGRADING.md
@@ -1,0 +1,26 @@
+# Upgrading datocms-plugin-sdk
+
+## v3.0.0 — Semantic color tokens
+
+The plugin context now exposes a `semanticColorTokensTheme` field with the
+active color palette for the current DatoCMS host. This is the new source
+of truth for plugin theming and supports dark mode.
+
+### What's new
+
+- `ctx.semanticColorTokensTheme` — a record of semantic color token values
+  (e.g. `colorSurface`, `colorInk`, `colorPrimarySurface`, …). The host
+  computes these for the user's active theme, including dark mode.
+- `ctx.theme` — still present and unchanged in shape, but **deprecated**.
+  Kept for backward compatibility with third-party plugins that read it
+  directly.
+
+### Action required
+
+If your plugin uses `datocms-react-ui`, see
+[its upgrade notes](../react-ui/UPGRADING.md) — most of the visible
+changes are there, including the dark-mode audit checklist.
+
+If your plugin reads `ctx.theme` directly, you can keep doing so for now.
+Migrating to `ctx.semanticColorTokensTheme` will let your plugin follow
+the user's active theme (including dark mode).

--- a/packages/sdk/UPGRADING.md
+++ b/packages/sdk/UPGRADING.md
@@ -25,12 +25,12 @@ of truth for plugin theming and supports dark mode.
   from it) keep rendering exactly as they did before.
 - `ctx.colorScheme` — `'light'` or `'dark'`. The host has already resolved
   `'system'` for you. The SDK runtime also writes
-  `document.documentElement.dataset.theme` to `"light"` / `"dark"` on
-  initial handshake and on every ctx update, so you can theme with CSS
+  `document.documentElement.dataset.colorScheme` to `"light"` / `"dark"`
+  on initial handshake and on every ctx update, so you can theme with CSS
   selectors like:
 
   ```css
-  [data-theme="dark"] .my-panel { background: #222; }
+  [data-color-scheme="dark"] .my-panel { background: #222; }
   ```
 
   For non-CSS decisions (picking a logo asset, a syntax-highlighting

--- a/packages/sdk/manifest.json
+++ b/packages/sdk/manifest.json
@@ -3127,6 +3127,16 @@
               "lineNumber": 99
             },
             "type": "SemanticColorTokensTheme"
+          },
+          "colorScheme": {
+            "comment": {
+              "markdownText": "The appearance color scheme the host CMS is currently using. Resolved —\n`'system'` is already expanded to `'light'` or `'dark'` by the host.\n\nThe SDK runtime reflects this onto `document.documentElement` as\n`data-theme=\"light\"` / `data-theme=\"dark\"` so plugin CSS can branch\nwith `[data-theme=\"dark\"] { … }` selectors. For non-CSS decisions\n(choosing a logo asset, a syntax-highlighting preset, …) branch on\n`ctx.colorScheme` directly."
+            },
+            "location": {
+              "filePath": "src/ctx/base.ts",
+              "lineNumber": 111
+            },
+            "type": "'light' | 'dark'"
           }
         }
       },
@@ -3142,7 +3152,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 109
+              "lineNumber": 121
             },
             "type": "Partial<Record<string, ItemType>>"
           },
@@ -3152,7 +3162,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 116
+              "lineNumber": 128
             },
             "type": "Partial<Record<string, Field>>"
           },
@@ -3162,7 +3172,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 123
+              "lineNumber": 135
             },
             "type": "Partial<Record<string, Fieldset>>"
           },
@@ -3172,7 +3182,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 130
+              "lineNumber": 142
             },
             "type": "Partial<Record<string, User>>"
           },
@@ -3182,7 +3192,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 137
+              "lineNumber": 149
             },
             "type": "Partial<Record<string, SsoUser>>"
           }
@@ -3203,7 +3213,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 341
+              "lineNumber": 353
             },
             "type": "(itemTypeId: string) => Promise<Field[]>"
           },
@@ -3214,7 +3224,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 360
+              "lineNumber": 372
             },
             "type": "(itemTypeId: string) => Promise<Fieldset[]>"
           },
@@ -3225,7 +3235,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 377
+              "lineNumber": 389
             },
             "type": "() => Promise<Field[]>"
           },
@@ -3236,7 +3246,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 390
+              "lineNumber": 402
             },
             "type": "() => Promise<User[]>"
           },
@@ -3247,7 +3257,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 403
+              "lineNumber": 415
             },
             "type": "() => Promise<SsoUser[]>"
           }
@@ -3266,7 +3276,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 425
+              "lineNumber": 437
             },
             "type": "(params: Record<string, unknown>) => Promise<void>"
           },
@@ -3277,7 +3287,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 476
+              "lineNumber": 488
             },
             "type": "(\n    fieldId: string,\n    changes: FieldAppearanceChange[],\n  ) => Promise<void>"
           }
@@ -3296,7 +3306,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 581
+              "lineNumber": 593
             },
             "type": "(message: string) => Promise<void>"
           },
@@ -3307,7 +3317,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 596
+              "lineNumber": 608
             },
             "type": "(message: string) => Promise<void>"
           },
@@ -3318,7 +3328,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 620
+              "lineNumber": 632
             },
             "type": "<CtaValue = unknown>(\n    toast: Toast<CtaValue>,\n  ) => Promise<CtaValue | null>"
           }
@@ -3337,7 +3347,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 506
+              "lineNumber": 518
             },
             "type": "(itemTypeId: string) => Promise<Item | null>"
           },
@@ -3348,7 +3358,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 527
+              "lineNumber": 539
             },
             "type": "{\n    (\n      itemTypeId: string,\n      options: { multiple: true; initialLocationQuery?: ItemListLocationQuery },\n    ): Promise<Item[] | null>;\n    (\n      itemTypeId: string,\n      options?: {\n        multiple: false;\n        initialLocationQuery?: ItemListLocationQuery;\n      },\n    ): Promise<Item | null>;\n  }"
           },
@@ -3359,7 +3369,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 559
+              "lineNumber": 571
             },
             "type": "(itemId: string) => Promise<Item | null>"
           }
@@ -3378,7 +3388,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 647
+              "lineNumber": 659
             },
             "type": "{\n    (options: { multiple: true }): Promise<Upload[] | null>;\n    (options?: { multiple: false }): Promise<Upload | null>;\n  }"
           },
@@ -3389,7 +3399,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 675
+              "lineNumber": 687
             },
             "type": "(\n    uploadId: string,\n  ) => Promise<(Upload & { deleted?: true }) | null>"
           },
@@ -3400,7 +3410,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 703
+              "lineNumber": 715
             },
             "type": "(\n    /** The \"single asset\" field structure */\n    fileFieldValue: FileFieldValue,\n    /** Shows metadata information for a specific locale */\n    locale?: string,\n  ) => Promise<FileFieldValue | null>"
           }
@@ -3419,7 +3429,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 734
+              "lineNumber": 746
             },
             "type": "(modal: Modal) => Promise<unknown>"
           },
@@ -3430,7 +3440,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 771
+              "lineNumber": 783
             },
             "type": "(options: ConfirmOptions) => Promise<unknown>"
           }
@@ -3449,7 +3459,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 785
+              "lineNumber": 797
             },
             "type": "(path: string) => Promise<void>"
           }

--- a/packages/sdk/manifest.json
+++ b/packages/sdk/manifest.json
@@ -3146,7 +3146,7 @@
               "filePath": "src/ctx/base.ts",
               "lineNumber": 119
             },
-            "type": "cssDesignTokens"
+            "type": "CssDesignTokens"
           },
           "colorScheme": {
             "comment": {

--- a/packages/sdk/manifest.json
+++ b/packages/sdk/manifest.json
@@ -3150,11 +3150,11 @@
           },
           "colorScheme": {
             "comment": {
-              "markdownText": "The appearance color scheme the host CMS is currently using. Resolved —\n`'system'` is already expanded to `'light'` or `'dark'` by the host.\n\nThe SDK runtime reflects this onto `document.documentElement` as\n`data-theme=\"light\"` / `data-theme=\"dark\"` so plugin CSS can branch\nwith `[data-theme=\"dark\"] { … }` selectors. For non-CSS decisions\n(choosing a logo asset, a syntax-highlighting preset, …) branch on\n`ctx.colorScheme` directly."
+              "markdownText": "The appearance color scheme the host CMS is currently using. Resolved —\n`'system'` is already expanded to `'light'` or `'dark'` by the host.\n\nThe SDK runtime reflects this onto `document.documentElement` as\n`data-color-scheme=\"light\"` / `data-color-scheme=\"dark\"` so plugin CSS\ncan branch with `[data-color-scheme=\"dark\"] { … }` selectors. For\nnon-CSS decisions\n(choosing a logo asset, a syntax-highlighting preset, …) branch on\n`ctx.colorScheme` directly."
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 131
+              "lineNumber": 132
             },
             "type": "'light' | 'dark'"
           }
@@ -3172,7 +3172,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 141
+              "lineNumber": 142
             },
             "type": "Partial<Record<string, ItemType>>"
           },
@@ -3182,7 +3182,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 148
+              "lineNumber": 149
             },
             "type": "Partial<Record<string, Field>>"
           },
@@ -3192,7 +3192,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 155
+              "lineNumber": 156
             },
             "type": "Partial<Record<string, Fieldset>>"
           },
@@ -3202,7 +3202,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 162
+              "lineNumber": 163
             },
             "type": "Partial<Record<string, User>>"
           },
@@ -3212,7 +3212,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 169
+              "lineNumber": 170
             },
             "type": "Partial<Record<string, SsoUser>>"
           }
@@ -3233,7 +3233,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 232
+              "lineNumber": 233
             },
             "type": "(itemTypeId: string) => Promise<Field[]>"
           },
@@ -3244,7 +3244,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 251
+              "lineNumber": 252
             },
             "type": "(itemTypeId: string) => Promise<Fieldset[]>"
           },
@@ -3255,7 +3255,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 268
+              "lineNumber": 269
             },
             "type": "() => Promise<Field[]>"
           },
@@ -3266,7 +3266,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 281
+              "lineNumber": 282
             },
             "type": "() => Promise<User[]>"
           },
@@ -3277,7 +3277,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 294
+              "lineNumber": 295
             },
             "type": "() => Promise<SsoUser[]>"
           }
@@ -3296,7 +3296,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 316
+              "lineNumber": 317
             },
             "type": "(params: Record<string, unknown>) => Promise<void>"
           },
@@ -3307,7 +3307,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 367
+              "lineNumber": 368
             },
             "type": "(\n    fieldId: string,\n    changes: FieldAppearanceChange[],\n  ) => Promise<void>"
           }
@@ -3326,7 +3326,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 472
+              "lineNumber": 473
             },
             "type": "(message: string) => Promise<void>"
           },
@@ -3337,7 +3337,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 487
+              "lineNumber": 488
             },
             "type": "(message: string) => Promise<void>"
           },
@@ -3348,7 +3348,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 511
+              "lineNumber": 512
             },
             "type": "<CtaValue = unknown>(\n    toast: Toast<CtaValue>,\n  ) => Promise<CtaValue | null>"
           }
@@ -3367,7 +3367,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 397
+              "lineNumber": 398
             },
             "type": "(itemTypeId: string) => Promise<Item | null>"
           },
@@ -3378,7 +3378,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 418
+              "lineNumber": 419
             },
             "type": "{\n    (\n      itemTypeId: string,\n      options: { multiple: true; initialLocationQuery?: ItemListLocationQuery },\n    ): Promise<Item[] | null>;\n    (\n      itemTypeId: string,\n      options?: {\n        multiple: false;\n        initialLocationQuery?: ItemListLocationQuery;\n      },\n    ): Promise<Item | null>;\n  }"
           },
@@ -3389,7 +3389,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 450
+              "lineNumber": 451
             },
             "type": "(itemId: string) => Promise<Item | null>"
           }
@@ -3408,7 +3408,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 538
+              "lineNumber": 539
             },
             "type": "{\n    (options: { multiple: true }): Promise<Upload[] | null>;\n    (options?: { multiple: false }): Promise<Upload | null>;\n  }"
           },
@@ -3419,7 +3419,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 566
+              "lineNumber": 567
             },
             "type": "(\n    uploadId: string,\n  ) => Promise<(Upload & { deleted?: true }) | null>"
           },
@@ -3430,7 +3430,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 594
+              "lineNumber": 595
             },
             "type": "(\n    /** The \"single asset\" field structure */\n    fileFieldValue: FileFieldValue,\n    /** Shows metadata information for a specific locale */\n    locale?: string,\n  ) => Promise<FileFieldValue | null>"
           }
@@ -3449,7 +3449,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 625
+              "lineNumber": 626
             },
             "type": "(modal: Modal) => Promise<unknown>"
           },
@@ -3460,7 +3460,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 662
+              "lineNumber": 663
             },
             "type": "(options: ConfirmOptions) => Promise<unknown>"
           }
@@ -3479,7 +3479,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 676
+              "lineNumber": 677
             },
             "type": "(path: string) => Promise<void>"
           }

--- a/packages/sdk/manifest.json
+++ b/packages/sdk/manifest.json
@@ -3150,11 +3150,11 @@
           },
           "colorScheme": {
             "comment": {
-              "markdownText": "The appearance color scheme the host CMS is currently using. Resolved —\n`'system'` is already expanded to `'light'` or `'dark'` by the host.\n\nThe SDK runtime reflects this onto `document.documentElement` as\n`data-color-scheme=\"light\"` / `data-color-scheme=\"dark\"` so plugin CSS\ncan branch with `[data-color-scheme=\"dark\"] { … }` selectors. For\nnon-CSS decisions\n(choosing a logo asset, a syntax-highlighting preset, …) branch on\n`ctx.colorScheme` directly."
+              "markdownText": "The appearance color scheme the host CMS is currently using. Resolved —\n`'system'` is already expanded to `'light'` or `'dark'` by the host.\n\nThe SDK runtime reflects this onto `document.documentElement` two ways:\nthe `data-color-scheme=\"light\"` / `data-color-scheme=\"dark\"` attribute,\nso plugin CSS can branch with `[data-color-scheme=\"dark\"] { … }`\nselectors; and the actual `color-scheme` CSS property, so `light-dark()`\nresolves to the correct branch (and native form controls / scrollbars\nmatch) everywhere in the plugin frame. For non-CSS decisions (choosing a\nlogo asset, a syntax-highlighting preset, …) branch on `ctx.colorScheme`\ndirectly."
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 132
+              "lineNumber": 134
             },
             "type": "'light' | 'dark'"
           }
@@ -3172,7 +3172,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 142
+              "lineNumber": 144
             },
             "type": "Partial<Record<string, ItemType>>"
           },
@@ -3182,7 +3182,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 149
+              "lineNumber": 151
             },
             "type": "Partial<Record<string, Field>>"
           },
@@ -3192,7 +3192,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 156
+              "lineNumber": 158
             },
             "type": "Partial<Record<string, Fieldset>>"
           },
@@ -3202,7 +3202,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 163
+              "lineNumber": 165
             },
             "type": "Partial<Record<string, User>>"
           },
@@ -3212,7 +3212,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 170
+              "lineNumber": 172
             },
             "type": "Partial<Record<string, SsoUser>>"
           }
@@ -3233,7 +3233,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 233
+              "lineNumber": 235
             },
             "type": "(itemTypeId: string) => Promise<Field[]>"
           },
@@ -3244,7 +3244,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 252
+              "lineNumber": 254
             },
             "type": "(itemTypeId: string) => Promise<Fieldset[]>"
           },
@@ -3255,7 +3255,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 269
+              "lineNumber": 271
             },
             "type": "() => Promise<Field[]>"
           },
@@ -3266,7 +3266,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 282
+              "lineNumber": 284
             },
             "type": "() => Promise<User[]>"
           },
@@ -3277,7 +3277,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 295
+              "lineNumber": 297
             },
             "type": "() => Promise<SsoUser[]>"
           }
@@ -3296,7 +3296,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 317
+              "lineNumber": 319
             },
             "type": "(params: Record<string, unknown>) => Promise<void>"
           },
@@ -3307,7 +3307,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 368
+              "lineNumber": 370
             },
             "type": "(\n    fieldId: string,\n    changes: FieldAppearanceChange[],\n  ) => Promise<void>"
           }
@@ -3326,7 +3326,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 473
+              "lineNumber": 475
             },
             "type": "(message: string) => Promise<void>"
           },
@@ -3337,7 +3337,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 488
+              "lineNumber": 490
             },
             "type": "(message: string) => Promise<void>"
           },
@@ -3348,7 +3348,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 512
+              "lineNumber": 514
             },
             "type": "<CtaValue = unknown>(\n    toast: Toast<CtaValue>,\n  ) => Promise<CtaValue | null>"
           }
@@ -3367,7 +3367,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 398
+              "lineNumber": 400
             },
             "type": "(itemTypeId: string) => Promise<Item | null>"
           },
@@ -3378,7 +3378,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 419
+              "lineNumber": 421
             },
             "type": "{\n    (\n      itemTypeId: string,\n      options: { multiple: true; initialLocationQuery?: ItemListLocationQuery },\n    ): Promise<Item[] | null>;\n    (\n      itemTypeId: string,\n      options?: {\n        multiple: false;\n        initialLocationQuery?: ItemListLocationQuery;\n      },\n    ): Promise<Item | null>;\n  }"
           },
@@ -3389,7 +3389,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 451
+              "lineNumber": 453
             },
             "type": "(itemId: string) => Promise<Item | null>"
           }
@@ -3408,7 +3408,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 539
+              "lineNumber": 541
             },
             "type": "{\n    (options: { multiple: true }): Promise<Upload[] | null>;\n    (options?: { multiple: false }): Promise<Upload | null>;\n  }"
           },
@@ -3419,7 +3419,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 567
+              "lineNumber": 569
             },
             "type": "(\n    uploadId: string,\n  ) => Promise<(Upload & { deleted?: true }) | null>"
           },
@@ -3430,7 +3430,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 595
+              "lineNumber": 597
             },
             "type": "(\n    /** The \"single asset\" field structure */\n    fileFieldValue: FileFieldValue,\n    /** Shows metadata information for a specific locale */\n    locale?: string,\n  ) => Promise<FileFieldValue | null>"
           }
@@ -3449,7 +3449,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 626
+              "lineNumber": 628
             },
             "type": "(modal: Modal) => Promise<unknown>"
           },
@@ -3460,7 +3460,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 663
+              "lineNumber": 665
             },
             "type": "(options: ConfirmOptions) => Promise<unknown>"
           }
@@ -3479,7 +3479,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 677
+              "lineNumber": 679
             },
             "type": "(path: string) => Promise<void>"
           }

--- a/packages/sdk/manifest.json
+++ b/packages/sdk/manifest.json
@@ -3130,7 +3130,7 @@
           "theme": {
             "comment": {
               "markdownText": "An object containing the theme colors for the current DatoCMS project.",
-              "deprecatedMarkdownText": "Use `semanticColorTokensTheme` instead. This property is kept\nfor backward compatibility with third-party plugins."
+              "deprecatedMarkdownText": "Use `cssDesignTokens` instead. This property is kept\nfor backward compatibility with third-party plugins."
             },
             "location": {
               "filePath": "src/ctx/base.ts",
@@ -3138,7 +3138,7 @@
             },
             "type": "Theme"
           },
-          "semanticColorTokensTheme": {
+          "cssDesignTokens": {
             "comment": {
               "markdownText": "Semantic color tokens for the current DatoCMS project, pre-computed by\nthe host. A map of CSS custom property names (e.g.\n`--color--raised--surface`) to their resolved values for the current\ncolor scheme."
             },
@@ -3146,7 +3146,7 @@
               "filePath": "src/ctx/base.ts",
               "lineNumber": 119
             },
-            "type": "SemanticColorTokensTheme"
+            "type": "cssDesignTokens"
           },
           "colorScheme": {
             "comment": {

--- a/packages/sdk/manifest.json
+++ b/packages/sdk/manifest.json
@@ -3109,13 +3109,24 @@
           },
           "theme": {
             "comment": {
-              "markdownText": "An object containing the theme colors for the current DatoCMS project."
+              "markdownText": "An object containing the theme colors for the current DatoCMS project.",
+              "deprecatedMarkdownText": "Use `semanticColorTokensTheme` instead. This property is kept\nfor backward compatibility with third-party plugins."
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 87
+              "lineNumber": 92
             },
             "type": "Theme"
+          },
+          "semanticColorTokensTheme": {
+            "comment": {
+              "markdownText": "Semantic color tokens for the current DatoCMS project, pre-computed by\nthe host. Only available on DatoCMS hosts that support the new token\nsystem."
+            },
+            "location": {
+              "filePath": "src/ctx/base.ts",
+              "lineNumber": 99
+            },
+            "type": "SemanticColorTokensTheme"
           }
         }
       },
@@ -3131,7 +3142,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 97
+              "lineNumber": 109
             },
             "type": "Partial<Record<string, ItemType>>"
           },
@@ -3141,7 +3152,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 104
+              "lineNumber": 116
             },
             "type": "Partial<Record<string, Field>>"
           },
@@ -3151,7 +3162,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 111
+              "lineNumber": 123
             },
             "type": "Partial<Record<string, Fieldset>>"
           },
@@ -3161,7 +3172,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 118
+              "lineNumber": 130
             },
             "type": "Partial<Record<string, User>>"
           },
@@ -3171,7 +3182,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 125
+              "lineNumber": 137
             },
             "type": "Partial<Record<string, SsoUser>>"
           }
@@ -3192,7 +3203,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 168
+              "lineNumber": 341
             },
             "type": "(itemTypeId: string) => Promise<Field[]>"
           },
@@ -3203,7 +3214,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 187
+              "lineNumber": 360
             },
             "type": "(itemTypeId: string) => Promise<Fieldset[]>"
           },
@@ -3214,7 +3225,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 204
+              "lineNumber": 377
             },
             "type": "() => Promise<Field[]>"
           },
@@ -3225,7 +3236,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 217
+              "lineNumber": 390
             },
             "type": "() => Promise<User[]>"
           },
@@ -3236,7 +3247,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 230
+              "lineNumber": 403
             },
             "type": "() => Promise<SsoUser[]>"
           }
@@ -3255,7 +3266,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 252
+              "lineNumber": 425
             },
             "type": "(params: Record<string, unknown>) => Promise<void>"
           },
@@ -3266,7 +3277,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 303
+              "lineNumber": 476
             },
             "type": "(\n    fieldId: string,\n    changes: FieldAppearanceChange[],\n  ) => Promise<void>"
           }
@@ -3285,7 +3296,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 408
+              "lineNumber": 581
             },
             "type": "(message: string) => Promise<void>"
           },
@@ -3296,7 +3307,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 423
+              "lineNumber": 596
             },
             "type": "(message: string) => Promise<void>"
           },
@@ -3307,7 +3318,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 447
+              "lineNumber": 620
             },
             "type": "<CtaValue = unknown>(\n    toast: Toast<CtaValue>,\n  ) => Promise<CtaValue | null>"
           }
@@ -3326,7 +3337,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 333
+              "lineNumber": 506
             },
             "type": "(itemTypeId: string) => Promise<Item | null>"
           },
@@ -3337,7 +3348,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 354
+              "lineNumber": 527
             },
             "type": "{\n    (\n      itemTypeId: string,\n      options: { multiple: true; initialLocationQuery?: ItemListLocationQuery },\n    ): Promise<Item[] | null>;\n    (\n      itemTypeId: string,\n      options?: {\n        multiple: false;\n        initialLocationQuery?: ItemListLocationQuery;\n      },\n    ): Promise<Item | null>;\n  }"
           },
@@ -3348,7 +3359,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 386
+              "lineNumber": 559
             },
             "type": "(itemId: string) => Promise<Item | null>"
           }
@@ -3367,7 +3378,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 474
+              "lineNumber": 647
             },
             "type": "{\n    (options: { multiple: true }): Promise<Upload[] | null>;\n    (options?: { multiple: false }): Promise<Upload | null>;\n  }"
           },
@@ -3378,7 +3389,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 502
+              "lineNumber": 675
             },
             "type": "(\n    uploadId: string,\n  ) => Promise<(Upload & { deleted?: true }) | null>"
           },
@@ -3389,7 +3400,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 530
+              "lineNumber": 703
             },
             "type": "(\n    /** The \"single asset\" field structure */\n    fileFieldValue: FileFieldValue,\n    /** Shows metadata information for a specific locale */\n    locale?: string,\n  ) => Promise<FileFieldValue | null>"
           }
@@ -3408,7 +3419,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 561
+              "lineNumber": 734
             },
             "type": "(modal: Modal) => Promise<unknown>"
           },
@@ -3419,7 +3430,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 598
+              "lineNumber": 771
             },
             "type": "(options: ConfirmOptions) => Promise<unknown>"
           }
@@ -3438,7 +3449,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 612
+              "lineNumber": 785
             },
             "type": "(path: string) => Promise<void>"
           }

--- a/packages/sdk/manifest.json
+++ b/packages/sdk/manifest.json
@@ -3140,11 +3140,11 @@
           },
           "semanticColorTokensTheme": {
             "comment": {
-              "markdownText": "Semantic color tokens for the current DatoCMS project, pre-computed by\nthe host. A map of CSS custom property names (e.g.\n`--color--raised--surface`) to their resolved values for the current\ncolor scheme. Only available on DatoCMS hosts that support the new token\nsystem."
+              "markdownText": "Semantic color tokens for the current DatoCMS project, pre-computed by\nthe host. A map of CSS custom property names (e.g.\n`--color--raised--surface`) to their resolved values for the current\ncolor scheme."
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 120
+              "lineNumber": 119
             },
             "type": "SemanticColorTokensTheme"
           },
@@ -3154,7 +3154,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 132
+              "lineNumber": 131
             },
             "type": "'light' | 'dark'"
           }
@@ -3172,7 +3172,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 142
+              "lineNumber": 141
             },
             "type": "Partial<Record<string, ItemType>>"
           },
@@ -3182,7 +3182,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 149
+              "lineNumber": 148
             },
             "type": "Partial<Record<string, Field>>"
           },
@@ -3192,7 +3192,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 156
+              "lineNumber": 155
             },
             "type": "Partial<Record<string, Fieldset>>"
           },
@@ -3202,7 +3202,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 163
+              "lineNumber": 162
             },
             "type": "Partial<Record<string, User>>"
           },
@@ -3212,7 +3212,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 170
+              "lineNumber": 169
             },
             "type": "Partial<Record<string, SsoUser>>"
           }
@@ -3233,7 +3233,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 233
+              "lineNumber": 232
             },
             "type": "(itemTypeId: string) => Promise<Field[]>"
           },
@@ -3244,7 +3244,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 252
+              "lineNumber": 251
             },
             "type": "(itemTypeId: string) => Promise<Fieldset[]>"
           },
@@ -3255,7 +3255,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 269
+              "lineNumber": 268
             },
             "type": "() => Promise<Field[]>"
           },
@@ -3266,7 +3266,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 282
+              "lineNumber": 281
             },
             "type": "() => Promise<User[]>"
           },
@@ -3277,7 +3277,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 295
+              "lineNumber": 294
             },
             "type": "() => Promise<SsoUser[]>"
           }
@@ -3296,7 +3296,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 317
+              "lineNumber": 316
             },
             "type": "(params: Record<string, unknown>) => Promise<void>"
           },
@@ -3307,7 +3307,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 368
+              "lineNumber": 367
             },
             "type": "(\n    fieldId: string,\n    changes: FieldAppearanceChange[],\n  ) => Promise<void>"
           }
@@ -3326,7 +3326,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 473
+              "lineNumber": 472
             },
             "type": "(message: string) => Promise<void>"
           },
@@ -3337,7 +3337,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 488
+              "lineNumber": 487
             },
             "type": "(message: string) => Promise<void>"
           },
@@ -3348,7 +3348,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 512
+              "lineNumber": 511
             },
             "type": "<CtaValue = unknown>(\n    toast: Toast<CtaValue>,\n  ) => Promise<CtaValue | null>"
           }
@@ -3367,7 +3367,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 398
+              "lineNumber": 397
             },
             "type": "(itemTypeId: string) => Promise<Item | null>"
           },
@@ -3378,7 +3378,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 419
+              "lineNumber": 418
             },
             "type": "{\n    (\n      itemTypeId: string,\n      options: { multiple: true; initialLocationQuery?: ItemListLocationQuery },\n    ): Promise<Item[] | null>;\n    (\n      itemTypeId: string,\n      options?: {\n        multiple: false;\n        initialLocationQuery?: ItemListLocationQuery;\n      },\n    ): Promise<Item | null>;\n  }"
           },
@@ -3389,7 +3389,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 451
+              "lineNumber": 450
             },
             "type": "(itemId: string) => Promise<Item | null>"
           }
@@ -3408,7 +3408,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 539
+              "lineNumber": 538
             },
             "type": "{\n    (options: { multiple: true }): Promise<Upload[] | null>;\n    (options?: { multiple: false }): Promise<Upload | null>;\n  }"
           },
@@ -3419,7 +3419,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 567
+              "lineNumber": 566
             },
             "type": "(\n    uploadId: string,\n  ) => Promise<(Upload & { deleted?: true }) | null>"
           },
@@ -3430,7 +3430,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 595
+              "lineNumber": 594
             },
             "type": "(\n    /** The \"single asset\" field structure */\n    fileFieldValue: FileFieldValue,\n    /** Shows metadata information for a specific locale */\n    locale?: string,\n  ) => Promise<FileFieldValue | null>"
           }
@@ -3449,7 +3449,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 626
+              "lineNumber": 625
             },
             "type": "(modal: Modal) => Promise<unknown>"
           },
@@ -3460,7 +3460,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 663
+              "lineNumber": 662
             },
             "type": "(options: ConfirmOptions) => Promise<unknown>"
           }
@@ -3479,7 +3479,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 677
+              "lineNumber": 676
             },
             "type": "(path: string) => Promise<void>"
           }

--- a/packages/sdk/manifest.json
+++ b/packages/sdk/manifest.json
@@ -3129,13 +3129,34 @@
           },
           "theme": {
             "comment": {
-              "markdownText": "An object containing the theme colors for the current DatoCMS project."
+              "markdownText": "An object containing the theme colors for the current DatoCMS project.",
+              "deprecatedMarkdownText": "Use `semanticColorTokensTheme` instead. This property is kept\nfor backward compatibility with third-party plugins."
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 106
+              "lineNumber": 111
             },
             "type": "Theme"
+          },
+          "semanticColorTokensTheme": {
+            "comment": {
+              "markdownText": "Semantic color tokens for the current DatoCMS project, pre-computed by\nthe host. A map of CSS custom property names (e.g.\n`--color--raised--surface`) to their resolved values for the current\ncolor scheme. Only available on DatoCMS hosts that support the new token\nsystem."
+            },
+            "location": {
+              "filePath": "src/ctx/base.ts",
+              "lineNumber": 120
+            },
+            "type": "SemanticColorTokensTheme"
+          },
+          "colorScheme": {
+            "comment": {
+              "markdownText": "The appearance color scheme the host CMS is currently using. Resolved —\n`'system'` is already expanded to `'light'` or `'dark'` by the host.\n\nThe SDK runtime reflects this onto `document.documentElement` as\n`data-theme=\"light\"` / `data-theme=\"dark\"` so plugin CSS can branch\nwith `[data-theme=\"dark\"] { … }` selectors. For non-CSS decisions\n(choosing a logo asset, a syntax-highlighting preset, …) branch on\n`ctx.colorScheme` directly."
+            },
+            "location": {
+              "filePath": "src/ctx/base.ts",
+              "lineNumber": 132
+            },
+            "type": "'light' | 'dark'"
           }
         }
       },
@@ -3151,7 +3172,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 116
+              "lineNumber": 142
             },
             "type": "Partial<Record<string, ItemType>>"
           },
@@ -3161,7 +3182,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 123
+              "lineNumber": 149
             },
             "type": "Partial<Record<string, Field>>"
           },
@@ -3171,7 +3192,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 130
+              "lineNumber": 156
             },
             "type": "Partial<Record<string, Fieldset>>"
           },
@@ -3181,7 +3202,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 137
+              "lineNumber": 163
             },
             "type": "Partial<Record<string, User>>"
           },
@@ -3191,7 +3212,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 144
+              "lineNumber": 170
             },
             "type": "Partial<Record<string, SsoUser>>"
           }
@@ -3212,7 +3233,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 187
+              "lineNumber": 233
             },
             "type": "(itemTypeId: string) => Promise<Field[]>"
           },
@@ -3223,7 +3244,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 206
+              "lineNumber": 252
             },
             "type": "(itemTypeId: string) => Promise<Fieldset[]>"
           },
@@ -3234,7 +3255,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 223
+              "lineNumber": 269
             },
             "type": "() => Promise<Field[]>"
           },
@@ -3245,7 +3266,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 236
+              "lineNumber": 282
             },
             "type": "() => Promise<User[]>"
           },
@@ -3256,7 +3277,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 249
+              "lineNumber": 295
             },
             "type": "() => Promise<SsoUser[]>"
           }
@@ -3275,7 +3296,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 271
+              "lineNumber": 317
             },
             "type": "(params: Record<string, unknown>) => Promise<void>"
           },
@@ -3286,7 +3307,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 322
+              "lineNumber": 368
             },
             "type": "(\n    fieldId: string,\n    changes: FieldAppearanceChange[],\n  ) => Promise<void>"
           }
@@ -3305,7 +3326,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 427
+              "lineNumber": 473
             },
             "type": "(message: string) => Promise<void>"
           },
@@ -3316,7 +3337,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 442
+              "lineNumber": 488
             },
             "type": "(message: string) => Promise<void>"
           },
@@ -3327,7 +3348,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 466
+              "lineNumber": 512
             },
             "type": "<CtaValue = unknown>(\n    toast: Toast<CtaValue>,\n  ) => Promise<CtaValue | null>"
           }
@@ -3346,7 +3367,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 352
+              "lineNumber": 398
             },
             "type": "(itemTypeId: string) => Promise<Item | null>"
           },
@@ -3357,7 +3378,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 373
+              "lineNumber": 419
             },
             "type": "{\n    (\n      itemTypeId: string,\n      options: { multiple: true; initialLocationQuery?: ItemListLocationQuery },\n    ): Promise<Item[] | null>;\n    (\n      itemTypeId: string,\n      options?: {\n        multiple: false;\n        initialLocationQuery?: ItemListLocationQuery;\n      },\n    ): Promise<Item | null>;\n  }"
           },
@@ -3368,7 +3389,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 405
+              "lineNumber": 451
             },
             "type": "(itemId: string) => Promise<Item | null>"
           }
@@ -3387,7 +3408,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 493
+              "lineNumber": 539
             },
             "type": "{\n    (options: { multiple: true }): Promise<Upload[] | null>;\n    (options?: { multiple: false }): Promise<Upload | null>;\n  }"
           },
@@ -3398,7 +3419,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 521
+              "lineNumber": 567
             },
             "type": "(\n    uploadId: string,\n  ) => Promise<(Upload & { deleted?: true }) | null>"
           },
@@ -3409,7 +3430,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 549
+              "lineNumber": 595
             },
             "type": "(\n    /** The \"single asset\" field structure */\n    fileFieldValue: FileFieldValue,\n    /** Shows metadata information for a specific locale */\n    locale?: string,\n  ) => Promise<FileFieldValue | null>"
           }
@@ -3428,7 +3449,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 580
+              "lineNumber": 626
             },
             "type": "(modal: Modal) => Promise<unknown>"
           },
@@ -3439,7 +3460,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 617
+              "lineNumber": 663
             },
             "type": "(options: ConfirmOptions) => Promise<unknown>"
           }
@@ -3458,7 +3479,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 631
+              "lineNumber": 677
             },
             "type": "(path: string) => Promise<void>"
           }

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datocms-plugin-sdk",
-  "version": "2.1.1",
+  "version": "3.0.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-plugin-sdk",
-      "version": "2.1.1",
+      "version": "3.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@datocms/cma-client": "*",

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datocms-plugin-sdk",
-  "version": "2.2.0-alpha.2",
+  "version": "2.2.0-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-plugin-sdk",
-      "version": "2.2.0-alpha.2",
+      "version": "2.2.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@datocms/cma-client": "*",

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datocms-plugin-sdk",
-  "version": "2.1.5",
+  "version": "3.0.1-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-plugin-sdk",
-      "version": "2.1.5",
+      "version": "3.0.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@datocms/cma-client": "*",

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datocms-plugin-sdk",
-  "version": "2.2.0-alpha.1",
+  "version": "2.2.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-plugin-sdk",
-      "version": "2.2.0-alpha.1",
+      "version": "2.2.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@datocms/cma-client": "*",

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datocms-plugin-sdk",
-  "version": "2.2.0-alpha.0",
+  "version": "2.2.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-plugin-sdk",
-      "version": "2.2.0-alpha.0",
+      "version": "2.2.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@datocms/cma-client": "*",

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datocms-plugin-sdk",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.1-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-plugin-sdk",
-      "version": "3.0.0-alpha.0",
+      "version": "3.0.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@datocms/cma-client": "*",

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datocms-plugin-sdk",
-  "version": "3.0.1-alpha.0",
+  "version": "2.2.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-plugin-sdk",
-      "version": "3.0.1-alpha.0",
+      "version": "2.2.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@datocms/cma-client": "*",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-plugin-sdk",
-  "version": "2.1.1",
+  "version": "3.0.0-alpha.0",
   "description": "DatoCMS Plugin SDK",
   "keywords": [
     "datocms",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-plugin-sdk",
-  "version": "2.2.0-alpha.0",
+  "version": "2.2.0-alpha.1",
   "description": "DatoCMS Plugin SDK",
   "keywords": [
     "datocms",
@@ -46,5 +46,5 @@
     "glob": "^11.0.0",
     "typescript": "^5.6.2"
   },
-  "gitHead": "a523642c7188862c8431027e51ab479945dde5dd"
+  "gitHead": "6b88a998f0807c7da1e17afa6a8f0336aed7497f"
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-plugin-sdk",
-  "version": "2.2.0-alpha.2",
+  "version": "2.2.0-alpha.3",
   "description": "DatoCMS Plugin SDK",
   "keywords": [
     "datocms",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-plugin-sdk",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.1-alpha.0",
   "description": "DatoCMS Plugin SDK",
   "keywords": [
     "datocms",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-plugin-sdk",
-  "version": "3.0.1-alpha.0",
+  "version": "2.2.0-alpha.0",
   "description": "DatoCMS Plugin SDK",
   "keywords": [
     "datocms",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-plugin-sdk",
-  "version": "2.1.5",
+  "version": "3.0.1-alpha.0",
   "description": "DatoCMS Plugin SDK",
   "keywords": [
     "datocms",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -30,7 +30,8 @@
   "scripts": {
     "build": "npm run generate-manifest && tsc && tsc --project ./tsconfig.esnext.json",
     "generate-manifest": "tsx generateManifest.ts && biome format --write src/manifest.ts",
-    "prebuild": "rimraf dist"
+    "prebuild": "rimraf dist",
+    "install-in-place": "npm run build && rm -rf $INSTALL_PATH/node_modules/datocms-plugin-sdk/dist && cp -rf dist manifest.json $INSTALL_PATH/node_modules/datocms-plugin-sdk"
   },
   "bugs": {
     "url": "https://github.com/datocms/plugins-sdk/issues"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-plugin-sdk",
-  "version": "2.2.0-alpha.1",
+  "version": "2.2.0-alpha.2",
   "description": "DatoCMS Plugin SDK",
   "keywords": [
     "datocms",

--- a/packages/sdk/src/connect.ts
+++ b/packages/sdk/src/connect.ts
@@ -143,6 +143,12 @@ function applyColorScheme(properties: unknown): void {
   if (next !== 'light' && next !== 'dark') return;
   if (document.documentElement.dataset.colorScheme === next) return;
   document.documentElement.dataset.colorScheme = next;
+  // Also set the actual `color-scheme` CSS property on the root so that
+  // `light-dark()` resolves to the correct branch and native form controls /
+  // scrollbars match — everywhere in the plugin frame, including DOM rendered
+  // outside any `Canvas`/portal. The `data-color-scheme` attribute above is
+  // just a hook for explicit CSS branching; it doesn't drive `light-dark()`.
+  document.documentElement.style.colorScheme = next;
 }
 
 export async function connect(

--- a/packages/sdk/src/connect.ts
+++ b/packages/sdk/src/connect.ts
@@ -141,8 +141,8 @@ function applyColorScheme(properties: unknown): void {
   const next = (properties as { colorScheme?: 'light' | 'dark' } | null)
     ?.colorScheme;
   if (next !== 'light' && next !== 'dark') return;
-  if (document.documentElement.dataset.theme === next) return;
-  document.documentElement.dataset.theme = next;
+  if (document.documentElement.dataset.colorScheme === next) return;
+  document.documentElement.dataset.colorScheme = next;
 }
 
 export async function connect(

--- a/packages/sdk/src/connect.ts
+++ b/packages/sdk/src/connect.ts
@@ -176,7 +176,7 @@ export async function connect(
 
   const penpalConnection = connectToParent({
     methods: {
-      sdkVersion: () => '0.3.0',
+      sdkVersion: () => '0.3.1',
       implementedHooks: () =>
         Object.fromEntries(
           Object.keys(rawConfiguration).map((hook) => {

--- a/packages/sdk/src/connect.ts
+++ b/packages/sdk/src/connect.ts
@@ -136,6 +136,15 @@ export type FullConnectParameters = AssetSourcesHook &
   UploadSidebarsHook &
   ValidateManualFieldExtensionParametersHook;
 
+function applyColorScheme(properties: unknown): void {
+  if (typeof document === 'undefined') return;
+  const next = (properties as { colorScheme?: 'light' | 'dark' } | null)
+    ?.colorScheme;
+  if (next !== 'light' && next !== 'dark') return;
+  if (document.documentElement.dataset.theme === next) return;
+  document.documentElement.dataset.theme = next;
+}
+
 export async function connect(
   rawConfiguration: Partial<FullConnectParameters> = {},
 ): Promise<void> {
@@ -185,6 +194,7 @@ export async function connect(
         ),
       ),
       onChange(newSettings: unknown) {
+        applyColorScheme(newSettings);
         if (onChangeListener) {
           onChangeListener(newSettings);
         }
@@ -212,6 +222,7 @@ export async function connect(
 
   const methods = await penpalConnection.promise;
   const initialProperties = await methods.getSettings();
+  applyColorScheme(initialProperties);
 
   if (initialProperties.mode === 'onBoot') {
     let currentProperties = initialProperties;

--- a/packages/sdk/src/ctx/base.ts
+++ b/packages/sdk/src/ctx/base.ts
@@ -122,12 +122,14 @@ type ProjectProperties = {
    * The appearance color scheme the host CMS is currently using. Resolved —
    * `'system'` is already expanded to `'light'` or `'dark'` by the host.
    *
-   * The SDK runtime reflects this onto `document.documentElement` as
-   * `data-color-scheme="light"` / `data-color-scheme="dark"` so plugin CSS
-   * can branch with `[data-color-scheme="dark"] { … }` selectors. For
-   * non-CSS decisions
-   * (choosing a logo asset, a syntax-highlighting preset, …) branch on
-   * `ctx.colorScheme` directly.
+   * The SDK runtime reflects this onto `document.documentElement` two ways:
+   * the `data-color-scheme="light"` / `data-color-scheme="dark"` attribute,
+   * so plugin CSS can branch with `[data-color-scheme="dark"] { … }`
+   * selectors; and the actual `color-scheme` CSS property, so `light-dark()`
+   * resolves to the correct branch (and native form controls / scrollbars
+   * match) everywhere in the plugin frame. For non-CSS decisions (choosing a
+   * logo asset, a syntax-highlighting preset, …) branch on `ctx.colorScheme`
+   * directly.
    */
   colorScheme: 'light' | 'dark';
 };

--- a/packages/sdk/src/ctx/base.ts
+++ b/packages/sdk/src/ctx/base.ts
@@ -116,7 +116,7 @@ type ProjectProperties = {
    * `--color--raised--surface`) to their resolved values for the current
    * color scheme.
    */
-  cssDesignTokens: cssDesignTokens;
+  cssDesignTokens: CssDesignTokens;
 
   /**
    * The appearance color scheme the host CMS is currently using. Resolved —
@@ -199,7 +199,7 @@ export type Theme = {
  * The token set is whatever the host sends; it is intentionally untyped so it
  * can evolve on the host without an SDK release.
  */
-export type cssDesignTokens = Record<string, string>;
+export type CssDesignTokens = Record<string, string>;
 
 export type BaseMethods = LoadDataMethods &
   UpdatePluginParametersMethods &

--- a/packages/sdk/src/ctx/base.ts
+++ b/packages/sdk/src/ctx/base.ts
@@ -105,7 +105,7 @@ type ProjectProperties = {
   /**
    * An object containing the theme colors for the current DatoCMS project
    *
-   * @deprecated Use `semanticColorTokensTheme` instead. This property is kept
+   * @deprecated Use `cssDesignTokens` instead. This property is kept
    *   for backward compatibility with third-party plugins.
    */
   theme: Theme;
@@ -116,7 +116,7 @@ type ProjectProperties = {
    * `--color--raised--surface`) to their resolved values for the current
    * color scheme.
    */
-  semanticColorTokensTheme: SemanticColorTokensTheme;
+  cssDesignTokens: cssDesignTokens;
 
   /**
    * The appearance color scheme the host CMS is currently using. Resolved —
@@ -175,7 +175,7 @@ type EntityReposProperties = {
 /**
  * An object containing the theme colors for the current DatoCMS project
  *
- * @deprecated Use `SemanticColorTokensTheme` instead. This type is kept for
+ * @deprecated Use `cssDesignTokens` instead. This type is kept for
  *   backward compatibility with third-party plugins.
  */
 export type Theme = {
@@ -199,7 +199,7 @@ export type Theme = {
  * The token set is whatever the host sends; it is intentionally untyped so it
  * can evolve on the host without an SDK release.
  */
-export type SemanticColorTokensTheme = Record<string, string>;
+export type cssDesignTokens = Record<string, string>;
 
 export type BaseMethods = LoadDataMethods &
   UpdatePluginParametersMethods &

--- a/packages/sdk/src/ctx/base.ts
+++ b/packages/sdk/src/ctx/base.ts
@@ -83,8 +83,20 @@ type ProjectProperties = {
     locale: string;
   };
 
-  /** An object containing the theme colors for the current DatoCMS project */
+  /**
+   * An object containing the theme colors for the current DatoCMS project
+   *
+   * @deprecated Use `semanticColorTokensTheme` instead. This property is kept
+   *   for backward compatibility with third-party plugins.
+   */
   theme: Theme;
+
+  /**
+   * Semantic color tokens for the current DatoCMS project, pre-computed by
+   * the host. Only available on DatoCMS hosts that support the new token
+   * system.
+   */
+  semanticColorTokensTheme: SemanticColorTokensTheme;
 };
 
 /**
@@ -125,7 +137,12 @@ type EntityReposProperties = {
   ssoUsers: Partial<Record<string, SsoUser>>;
 };
 
-/** An object containing the theme colors for the current DatoCMS project */
+/**
+ * An object containing the theme colors for the current DatoCMS project
+ *
+ * @deprecated Use `SemanticColorTokensTheme` instead. This type is kept for
+ *   backward compatibility with third-party plugins.
+ */
 export type Theme = {
   primaryColor: string;
   accentColor: string;
@@ -133,6 +150,162 @@ export type Theme = {
   lightColor: string;
   darkColor: string;
 };
+
+/**
+ * Known semantic color tokens provided by the DatoCMS host.
+ * All properties are optional — the host may not send all of them.
+ *
+ * camelCase keys are converted to kebab-case CSS custom properties via
+ * `camelToDash`. For example, `colorRaisedSurface` becomes
+ * `--color-raised-surface`.
+ */
+type KnownSemanticColorTokens = {
+  /* --- Standalone --- */
+  colorSurface?: string;
+  colorSurfaceHover?: string;
+  colorSurfaceMuted?: string;
+  colorInk?: string;
+  colorInkSubtle?: string;
+  colorInkHover?: string;
+  colorInkMuted?: string;
+  colorInkPlaceholder?: string;
+  colorInkPrimary?: string;
+  colorInkAccent?: string;
+  colorInkDisabled?: string;
+  colorBorder?: string;
+  colorBorderHover?: string;
+
+  /* --- Context: raised --- */
+  colorRaisedSurface?: string;
+  colorRaisedSurfaceHover?: string;
+  colorRaisedSurfaceActive?: string;
+
+  /* --- Context: primary --- */
+  colorPrimarySurface?: string;
+  colorPrimarySurfaceHover?: string;
+  colorPrimarySurfaceActive?: string;
+  colorPrimarySurfaceMuted?: string;
+  colorPrimaryInk?: string;
+  colorPrimaryBorder?: string;
+
+  /* --- Context: tinted --- */
+  colorTintedSurface?: string;
+  colorTintedSurfaceHover?: string;
+  colorTintedSurfaceActive?: string;
+  colorTintedInk?: string;
+
+  /* --- Context: accent --- */
+  colorAccentSurface?: string;
+  colorAccentInk?: string;
+
+  /* --- Context: selected --- */
+  colorSelectedSurface?: string;
+  colorSelectedInk?: string;
+  colorSelectedBorder?: string;
+
+  /* --- Context: disabled --- */
+  colorDisabledSurface?: string;
+  colorDisabledInk?: string;
+
+  /* --- Context: danger --- */
+  colorDangerSurface?: string;
+  colorDangerInk?: string;
+
+  /* --- Context: enterprise --- */
+  colorEnterpriseSurface?: string;
+
+  /* --- Context: focus --- */
+  colorFocusBorder?: string;
+  colorFocusOutline?: string;
+
+  /* --- Feedback --- */
+  colorFeedbackFailInk?: string;
+  colorFeedbackFailBorder?: string;
+  colorFeedbackFailOutline?: string;
+  colorFeedbackWarningInk?: string;
+  colorFeedbackWarningSurface?: string;
+  colorFeedbackSuccessInk?: string;
+  colorFeedbackWarningBorder?: string;
+  colorFeedbackSuccessBorder?: string;
+
+  /* --- Context: highlight --- */
+  colorHighlightSurface?: string;
+
+  /* --- Diffs --- */
+  colorDiffAddedSurface?: string;
+  colorDiffRemovedSurface?: string;
+  colorDiffChangedSurface?: string;
+  colorDiffAddedSurfaceSubtle?: string;
+  colorDiffRemovedSurfaceSubtle?: string;
+  colorDiffChangedSurfaceSubtle?: string;
+  colorDiffAddedOutlineSubtle?: string;
+  colorDiffRemovedOutlineSubtle?: string;
+  colorDiffChangedOutlineSubtle?: string;
+  colorDiffChangedBorder?: string;
+  colorDiffChangedBorderNegative?: string;
+
+  /* --- Status --- */
+  colorStatusDraftInk?: string;
+  colorStatusOutdatedInk?: string;
+  colorStatusPublishedInk?: string;
+
+  /* --- Backdrop --- */
+  colorBackdropSurface?: string;
+  colorBackdropInk?: string;
+
+  /* --- Overlay --- */
+  colorOverlaySurface?: string;
+  colorOverlaySurfaceSubtle?: string;
+  colorOverlayInk?: string;
+
+  /* --- Stacked --- */
+  colorStackedSurfaceBase?: string;
+  colorStackedSurface?: string;
+  colorStackedSurfaceRaised?: string;
+  colorStackedInk?: string;
+  colorStackedInkSubtle?: string;
+  colorStackedBorder?: string;
+  colorStackedSurfaceHover?: string;
+  colorStackedSurfaceTranslucent?: string;
+  colorStackedSurfaceButton?: string;
+  colorStackedSurfaceButtonActive?: string;
+
+  /* --- Progress --- */
+  colorProgressTrack?: string;
+  colorProgressFill?: string;
+  colorProgressFillHover?: string;
+
+  /* --- Tooltip --- */
+  colorTooltipSurface?: string;
+  colorTooltipSurfaceHover?: string;
+  colorTooltipInk?: string;
+  colorTooltipInkSubtle?: string;
+
+  /* --- Code --- */
+  colorCodeSurface?: string;
+  colorCodeInk?: string;
+
+  /* --- Shadows --- */
+  colorShadowSubtle?: string;
+  colorShadow?: string;
+  colorShadowStrong?: string;
+
+  /* --- Scrollbar --- */
+  colorScrollbar?: string;
+
+  /* --- Shadow composites --- */
+  shadowElevated?: string;
+  shadowFloat?: string;
+  shadowAmbient?: string;
+};
+
+/**
+ * Semantic color tokens for the current DatoCMS project, pre-computed by the
+ * host. Known tokens get autocomplete; unknown tokens are accepted via the
+ * index signature for forward compatibility.
+ */
+export type SemanticColorTokensTheme = KnownSemanticColorTokens &
+  Record<string, string>;
 
 export type BaseMethods = LoadDataMethods &
   UpdatePluginParametersMethods &

--- a/packages/sdk/src/ctx/base.ts
+++ b/packages/sdk/src/ctx/base.ts
@@ -102,8 +102,33 @@ type ProjectProperties = {
     locale: string;
   };
 
-  /** An object containing the theme colors for the current DatoCMS project */
+  /**
+   * An object containing the theme colors for the current DatoCMS project
+   *
+   * @deprecated Use `semanticColorTokensTheme` instead. This property is kept
+   *   for backward compatibility with third-party plugins.
+   */
   theme: Theme;
+
+  /**
+   * Semantic color tokens for the current DatoCMS project, pre-computed by
+   * the host. A map of CSS custom property names (e.g.
+   * `--color--raised--surface`) to their resolved values for the current
+   * color scheme.
+   */
+  semanticColorTokensTheme: SemanticColorTokensTheme;
+
+  /**
+   * The appearance color scheme the host CMS is currently using. Resolved —
+   * `'system'` is already expanded to `'light'` or `'dark'` by the host.
+   *
+   * The SDK runtime reflects this onto `document.documentElement` as
+   * `data-theme="light"` / `data-theme="dark"` so plugin CSS can branch
+   * with `[data-theme="dark"] { … }` selectors. For non-CSS decisions
+   * (choosing a logo asset, a syntax-highlighting preset, …) branch on
+   * `ctx.colorScheme` directly.
+   */
+  colorScheme: 'light' | 'dark';
 };
 
 /**
@@ -144,7 +169,12 @@ type EntityReposProperties = {
   ssoUsers: Partial<Record<string, SsoUser>>;
 };
 
-/** An object containing the theme colors for the current DatoCMS project */
+/**
+ * An object containing the theme colors for the current DatoCMS project
+ *
+ * @deprecated Use `SemanticColorTokensTheme` instead. This type is kept for
+ *   backward compatibility with third-party plugins.
+ */
 export type Theme = {
   primaryColor: string;
   accentColor: string;
@@ -152,6 +182,21 @@ export type Theme = {
   lightColor: string;
   darkColor: string;
 };
+
+/**
+ * Semantic color tokens for the current DatoCMS project, pre-computed by the
+ * host. Only available on DatoCMS hosts that support the new token system.
+ *
+ * Each key is a ready-to-use CSS custom property name (including the leading
+ * `--`), and each value is the resolved color for the host's current color
+ * scheme — e.g. `{ '--color--raised--surface': 'oklch(…)' }`. The SDK applies
+ * these verbatim onto the plugin canvas, so plugin CSS can reference them
+ * directly with `var(--color--raised--surface)`.
+ *
+ * The token set is whatever the host sends; it is intentionally untyped so it
+ * can evolve on the host without an SDK release.
+ */
+export type SemanticColorTokensTheme = Record<string, string>;
 
 export type BaseMethods = LoadDataMethods &
   UpdatePluginParametersMethods &

--- a/packages/sdk/src/ctx/base.ts
+++ b/packages/sdk/src/ctx/base.ts
@@ -97,6 +97,18 @@ type ProjectProperties = {
    * system.
    */
   semanticColorTokensTheme: SemanticColorTokensTheme;
+
+  /**
+   * The appearance color scheme the host CMS is currently using. Resolved —
+   * `'system'` is already expanded to `'light'` or `'dark'` by the host.
+   *
+   * The SDK runtime reflects this onto `document.documentElement` as
+   * `data-theme="light"` / `data-theme="dark"` so plugin CSS can branch
+   * with `[data-theme="dark"] { … }` selectors. For non-CSS decisions
+   * (choosing a logo asset, a syntax-highlighting preset, …) branch on
+   * `ctx.colorScheme` directly.
+   */
+  colorScheme: 'light' | 'dark';
 };
 
 /**

--- a/packages/sdk/src/ctx/base.ts
+++ b/packages/sdk/src/ctx/base.ts
@@ -123,8 +123,9 @@ type ProjectProperties = {
    * `'system'` is already expanded to `'light'` or `'dark'` by the host.
    *
    * The SDK runtime reflects this onto `document.documentElement` as
-   * `data-theme="light"` / `data-theme="dark"` so plugin CSS can branch
-   * with `[data-theme="dark"] { … }` selectors. For non-CSS decisions
+   * `data-color-scheme="light"` / `data-color-scheme="dark"` so plugin CSS
+   * can branch with `[data-color-scheme="dark"] { … }` selectors. For
+   * non-CSS decisions
    * (choosing a logo asset, a syntax-highlighting preset, …) branch on
    * `ctx.colorScheme` directly.
    */

--- a/packages/sdk/src/manifest.ts
+++ b/packages/sdk/src/manifest.ts
@@ -3374,11 +3374,11 @@ export const manifest: Manifest = {
           semanticColorTokensTheme: {
             comment: {
               markdownText:
-                'Semantic color tokens for the current DatoCMS project, pre-computed by\nthe host. A map of CSS custom property names (e.g.\n`--color--raised--surface`) to their resolved values for the current\ncolor scheme. Only available on DatoCMS hosts that support the new token\nsystem.',
+                'Semantic color tokens for the current DatoCMS project, pre-computed by\nthe host. A map of CSS custom property names (e.g.\n`--color--raised--surface`) to their resolved values for the current\ncolor scheme.',
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 120,
+              lineNumber: 119,
             },
             type: 'SemanticColorTokensTheme',
           },
@@ -3389,7 +3389,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 132,
+              lineNumber: 131,
             },
             type: "'light' | 'dark'",
           },
@@ -3409,7 +3409,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 142,
+              lineNumber: 141,
             },
             type: 'Partial<Record<string, ItemType>>',
           },
@@ -3420,7 +3420,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 149,
+              lineNumber: 148,
             },
             type: 'Partial<Record<string, Field>>',
           },
@@ -3431,7 +3431,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 156,
+              lineNumber: 155,
             },
             type: 'Partial<Record<string, Fieldset>>',
           },
@@ -3442,7 +3442,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 163,
+              lineNumber: 162,
             },
             type: 'Partial<Record<string, User>>',
           },
@@ -3453,7 +3453,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 170,
+              lineNumber: 169,
             },
             type: 'Partial<Record<string, SsoUser>>',
           },
@@ -3477,7 +3477,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 233,
+              lineNumber: 232,
             },
             type: '(itemTypeId: string) => Promise<Field[]>',
           },
@@ -3490,7 +3490,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 252,
+              lineNumber: 251,
             },
             type: '(itemTypeId: string) => Promise<Fieldset[]>',
           },
@@ -3503,7 +3503,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 269,
+              lineNumber: 268,
             },
             type: '() => Promise<Field[]>',
           },
@@ -3516,7 +3516,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 282,
+              lineNumber: 281,
             },
             type: '() => Promise<User[]>',
           },
@@ -3529,7 +3529,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 295,
+              lineNumber: 294,
             },
             type: '() => Promise<SsoUser[]>',
           },
@@ -3551,7 +3551,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 317,
+              lineNumber: 316,
             },
             type: '(params: Record<string, unknown>) => Promise<void>',
           },
@@ -3564,7 +3564,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 368,
+              lineNumber: 367,
             },
             type: '(\n    fieldId: string,\n    changes: FieldAppearanceChange[],\n  ) => Promise<void>',
           },
@@ -3586,7 +3586,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 473,
+              lineNumber: 472,
             },
             type: '(message: string) => Promise<void>',
           },
@@ -3599,7 +3599,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 488,
+              lineNumber: 487,
             },
             type: '(message: string) => Promise<void>',
           },
@@ -3612,7 +3612,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 512,
+              lineNumber: 511,
             },
             type: '<CtaValue = unknown>(\n    toast: Toast<CtaValue>,\n  ) => Promise<CtaValue | null>',
           },
@@ -3634,7 +3634,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 398,
+              lineNumber: 397,
             },
             type: '(itemTypeId: string) => Promise<Item | null>',
           },
@@ -3647,7 +3647,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 419,
+              lineNumber: 418,
             },
             type: '{\n    (\n      itemTypeId: string,\n      options: { multiple: true; initialLocationQuery?: ItemListLocationQuery },\n    ): Promise<Item[] | null>;\n    (\n      itemTypeId: string,\n      options?: {\n        multiple: false;\n        initialLocationQuery?: ItemListLocationQuery;\n      },\n    ): Promise<Item | null>;\n  }',
           },
@@ -3660,7 +3660,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 451,
+              lineNumber: 450,
             },
             type: '(itemId: string) => Promise<Item | null>',
           },
@@ -3682,7 +3682,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 539,
+              lineNumber: 538,
             },
             type: '{\n    (options: { multiple: true }): Promise<Upload[] | null>;\n    (options?: { multiple: false }): Promise<Upload | null>;\n  }',
           },
@@ -3695,7 +3695,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 567,
+              lineNumber: 566,
             },
             type: '(\n    uploadId: string,\n  ) => Promise<(Upload & { deleted?: true }) | null>',
           },
@@ -3708,7 +3708,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 595,
+              lineNumber: 594,
             },
             type: '(\n    /** The "single asset" field structure */\n    fileFieldValue: FileFieldValue,\n    /** Shows metadata information for a specific locale */\n    locale?: string,\n  ) => Promise<FileFieldValue | null>',
           },
@@ -3730,7 +3730,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 626,
+              lineNumber: 625,
             },
             type: '(modal: Modal) => Promise<unknown>',
           },
@@ -3743,7 +3743,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 663,
+              lineNumber: 662,
             },
             type: '(options: ConfirmOptions) => Promise<unknown>',
           },
@@ -3764,7 +3764,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 677,
+              lineNumber: 676,
             },
             type: '(path: string) => Promise<void>',
           },

--- a/packages/sdk/src/manifest.ts
+++ b/packages/sdk/src/manifest.ts
@@ -3380,7 +3380,7 @@ export const manifest: Manifest = {
               filePath: 'src/ctx/base.ts',
               lineNumber: 119,
             },
-            type: 'cssDesignTokens',
+            type: 'CssDesignTokens',
           },
           colorScheme: {
             comment: {

--- a/packages/sdk/src/manifest.ts
+++ b/packages/sdk/src/manifest.ts
@@ -3340,12 +3340,25 @@ export const manifest: Manifest = {
             comment: {
               markdownText:
                 'An object containing the theme colors for the current DatoCMS project.',
+              deprecatedMarkdownText:
+                'Use `semanticColorTokensTheme` instead. This property is kept\nfor backward compatibility with third-party plugins.',
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 87,
+              lineNumber: 92,
             },
             type: 'Theme',
+          },
+          semanticColorTokensTheme: {
+            comment: {
+              markdownText:
+                'Semantic color tokens for the current DatoCMS project, pre-computed by\nthe host. Only available on DatoCMS hosts that support the new token\nsystem.',
+            },
+            location: {
+              filePath: 'src/ctx/base.ts',
+              lineNumber: 99,
+            },
+            type: 'SemanticColorTokensTheme',
           },
         },
       },
@@ -3363,7 +3376,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 97,
+              lineNumber: 109,
             },
             type: 'Partial<Record<string, ItemType>>',
           },
@@ -3374,7 +3387,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 104,
+              lineNumber: 116,
             },
             type: 'Partial<Record<string, Field>>',
           },
@@ -3385,7 +3398,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 111,
+              lineNumber: 123,
             },
             type: 'Partial<Record<string, Fieldset>>',
           },
@@ -3396,7 +3409,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 118,
+              lineNumber: 130,
             },
             type: 'Partial<Record<string, User>>',
           },
@@ -3407,7 +3420,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 125,
+              lineNumber: 137,
             },
             type: 'Partial<Record<string, SsoUser>>',
           },
@@ -3431,7 +3444,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 168,
+              lineNumber: 341,
             },
             type: '(itemTypeId: string) => Promise<Field[]>',
           },
@@ -3444,7 +3457,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 187,
+              lineNumber: 360,
             },
             type: '(itemTypeId: string) => Promise<Fieldset[]>',
           },
@@ -3457,7 +3470,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 204,
+              lineNumber: 377,
             },
             type: '() => Promise<Field[]>',
           },
@@ -3470,7 +3483,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 217,
+              lineNumber: 390,
             },
             type: '() => Promise<User[]>',
           },
@@ -3483,7 +3496,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 230,
+              lineNumber: 403,
             },
             type: '() => Promise<SsoUser[]>',
           },
@@ -3505,7 +3518,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 252,
+              lineNumber: 425,
             },
             type: '(params: Record<string, unknown>) => Promise<void>',
           },
@@ -3518,7 +3531,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 303,
+              lineNumber: 476,
             },
             type: '(\n    fieldId: string,\n    changes: FieldAppearanceChange[],\n  ) => Promise<void>',
           },
@@ -3540,7 +3553,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 408,
+              lineNumber: 581,
             },
             type: '(message: string) => Promise<void>',
           },
@@ -3553,7 +3566,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 423,
+              lineNumber: 596,
             },
             type: '(message: string) => Promise<void>',
           },
@@ -3566,7 +3579,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 447,
+              lineNumber: 620,
             },
             type: '<CtaValue = unknown>(\n    toast: Toast<CtaValue>,\n  ) => Promise<CtaValue | null>',
           },
@@ -3588,7 +3601,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 333,
+              lineNumber: 506,
             },
             type: '(itemTypeId: string) => Promise<Item | null>',
           },
@@ -3601,7 +3614,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 354,
+              lineNumber: 527,
             },
             type: '{\n    (\n      itemTypeId: string,\n      options: { multiple: true; initialLocationQuery?: ItemListLocationQuery },\n    ): Promise<Item[] | null>;\n    (\n      itemTypeId: string,\n      options?: {\n        multiple: false;\n        initialLocationQuery?: ItemListLocationQuery;\n      },\n    ): Promise<Item | null>;\n  }',
           },
@@ -3614,7 +3627,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 386,
+              lineNumber: 559,
             },
             type: '(itemId: string) => Promise<Item | null>',
           },
@@ -3636,7 +3649,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 474,
+              lineNumber: 647,
             },
             type: '{\n    (options: { multiple: true }): Promise<Upload[] | null>;\n    (options?: { multiple: false }): Promise<Upload | null>;\n  }',
           },
@@ -3649,7 +3662,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 502,
+              lineNumber: 675,
             },
             type: '(\n    uploadId: string,\n  ) => Promise<(Upload & { deleted?: true }) | null>',
           },
@@ -3662,7 +3675,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 530,
+              lineNumber: 703,
             },
             type: '(\n    /** The "single asset" field structure */\n    fileFieldValue: FileFieldValue,\n    /** Shows metadata information for a specific locale */\n    locale?: string,\n  ) => Promise<FileFieldValue | null>',
           },
@@ -3684,7 +3697,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 561,
+              lineNumber: 734,
             },
             type: '(modal: Modal) => Promise<unknown>',
           },
@@ -3697,7 +3710,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 598,
+              lineNumber: 771,
             },
             type: '(options: ConfirmOptions) => Promise<unknown>',
           },
@@ -3718,7 +3731,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 612,
+              lineNumber: 785,
             },
             type: '(path: string) => Promise<void>',
           },

--- a/packages/sdk/src/manifest.ts
+++ b/packages/sdk/src/manifest.ts
@@ -3385,11 +3385,11 @@ export const manifest: Manifest = {
           colorScheme: {
             comment: {
               markdownText:
-                'The appearance color scheme the host CMS is currently using. Resolved —\n`\'system\'` is already expanded to `\'light\'` or `\'dark\'` by the host.\n\nThe SDK runtime reflects this onto `document.documentElement` as\n`data-color-scheme="light"` / `data-color-scheme="dark"` so plugin CSS\ncan branch with `[data-color-scheme="dark"] { … }` selectors. For\nnon-CSS decisions\n(choosing a logo asset, a syntax-highlighting preset, …) branch on\n`ctx.colorScheme` directly.',
+                'The appearance color scheme the host CMS is currently using. Resolved —\n`\'system\'` is already expanded to `\'light\'` or `\'dark\'` by the host.\n\nThe SDK runtime reflects this onto `document.documentElement` two ways:\nthe `data-color-scheme="light"` / `data-color-scheme="dark"` attribute,\nso plugin CSS can branch with `[data-color-scheme="dark"] { … }`\nselectors; and the actual `color-scheme` CSS property, so `light-dark()`\nresolves to the correct branch (and native form controls / scrollbars\nmatch) everywhere in the plugin frame. For non-CSS decisions (choosing a\nlogo asset, a syntax-highlighting preset, …) branch on `ctx.colorScheme`\ndirectly.',
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 132,
+              lineNumber: 134,
             },
             type: "'light' | 'dark'",
           },
@@ -3409,7 +3409,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 142,
+              lineNumber: 144,
             },
             type: 'Partial<Record<string, ItemType>>',
           },
@@ -3420,7 +3420,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 149,
+              lineNumber: 151,
             },
             type: 'Partial<Record<string, Field>>',
           },
@@ -3431,7 +3431,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 156,
+              lineNumber: 158,
             },
             type: 'Partial<Record<string, Fieldset>>',
           },
@@ -3442,7 +3442,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 163,
+              lineNumber: 165,
             },
             type: 'Partial<Record<string, User>>',
           },
@@ -3453,7 +3453,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 170,
+              lineNumber: 172,
             },
             type: 'Partial<Record<string, SsoUser>>',
           },
@@ -3477,7 +3477,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 233,
+              lineNumber: 235,
             },
             type: '(itemTypeId: string) => Promise<Field[]>',
           },
@@ -3490,7 +3490,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 252,
+              lineNumber: 254,
             },
             type: '(itemTypeId: string) => Promise<Fieldset[]>',
           },
@@ -3503,7 +3503,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 269,
+              lineNumber: 271,
             },
             type: '() => Promise<Field[]>',
           },
@@ -3516,7 +3516,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 282,
+              lineNumber: 284,
             },
             type: '() => Promise<User[]>',
           },
@@ -3529,7 +3529,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 295,
+              lineNumber: 297,
             },
             type: '() => Promise<SsoUser[]>',
           },
@@ -3551,7 +3551,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 317,
+              lineNumber: 319,
             },
             type: '(params: Record<string, unknown>) => Promise<void>',
           },
@@ -3564,7 +3564,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 368,
+              lineNumber: 370,
             },
             type: '(\n    fieldId: string,\n    changes: FieldAppearanceChange[],\n  ) => Promise<void>',
           },
@@ -3586,7 +3586,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 473,
+              lineNumber: 475,
             },
             type: '(message: string) => Promise<void>',
           },
@@ -3599,7 +3599,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 488,
+              lineNumber: 490,
             },
             type: '(message: string) => Promise<void>',
           },
@@ -3612,7 +3612,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 512,
+              lineNumber: 514,
             },
             type: '<CtaValue = unknown>(\n    toast: Toast<CtaValue>,\n  ) => Promise<CtaValue | null>',
           },
@@ -3634,7 +3634,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 398,
+              lineNumber: 400,
             },
             type: '(itemTypeId: string) => Promise<Item | null>',
           },
@@ -3647,7 +3647,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 419,
+              lineNumber: 421,
             },
             type: '{\n    (\n      itemTypeId: string,\n      options: { multiple: true; initialLocationQuery?: ItemListLocationQuery },\n    ): Promise<Item[] | null>;\n    (\n      itemTypeId: string,\n      options?: {\n        multiple: false;\n        initialLocationQuery?: ItemListLocationQuery;\n      },\n    ): Promise<Item | null>;\n  }',
           },
@@ -3660,7 +3660,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 451,
+              lineNumber: 453,
             },
             type: '(itemId: string) => Promise<Item | null>',
           },
@@ -3682,7 +3682,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 539,
+              lineNumber: 541,
             },
             type: '{\n    (options: { multiple: true }): Promise<Upload[] | null>;\n    (options?: { multiple: false }): Promise<Upload | null>;\n  }',
           },
@@ -3695,7 +3695,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 567,
+              lineNumber: 569,
             },
             type: '(\n    uploadId: string,\n  ) => Promise<(Upload & { deleted?: true }) | null>',
           },
@@ -3708,7 +3708,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 595,
+              lineNumber: 597,
             },
             type: '(\n    /** The "single asset" field structure */\n    fileFieldValue: FileFieldValue,\n    /** Shows metadata information for a specific locale */\n    locale?: string,\n  ) => Promise<FileFieldValue | null>',
           },
@@ -3730,7 +3730,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 626,
+              lineNumber: 628,
             },
             type: '(modal: Modal) => Promise<unknown>',
           },
@@ -3743,7 +3743,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 663,
+              lineNumber: 665,
             },
             type: '(options: ConfirmOptions) => Promise<unknown>',
           },
@@ -3764,7 +3764,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 677,
+              lineNumber: 679,
             },
             type: '(path: string) => Promise<void>',
           },

--- a/packages/sdk/src/manifest.ts
+++ b/packages/sdk/src/manifest.ts
@@ -3363,7 +3363,7 @@ export const manifest: Manifest = {
               markdownText:
                 'An object containing the theme colors for the current DatoCMS project.',
               deprecatedMarkdownText:
-                'Use `semanticColorTokensTheme` instead. This property is kept\nfor backward compatibility with third-party plugins.',
+                'Use `cssDesignTokens` instead. This property is kept\nfor backward compatibility with third-party plugins.',
             },
             location: {
               filePath: 'src/ctx/base.ts',
@@ -3371,7 +3371,7 @@ export const manifest: Manifest = {
             },
             type: 'Theme',
           },
-          semanticColorTokensTheme: {
+          cssDesignTokens: {
             comment: {
               markdownText:
                 'Semantic color tokens for the current DatoCMS project, pre-computed by\nthe host. A map of CSS custom property names (e.g.\n`--color--raised--surface`) to their resolved values for the current\ncolor scheme.',
@@ -3380,7 +3380,7 @@ export const manifest: Manifest = {
               filePath: 'src/ctx/base.ts',
               lineNumber: 119,
             },
-            type: 'SemanticColorTokensTheme',
+            type: 'cssDesignTokens',
           },
           colorScheme: {
             comment: {

--- a/packages/sdk/src/manifest.ts
+++ b/packages/sdk/src/manifest.ts
@@ -3385,11 +3385,11 @@ export const manifest: Manifest = {
           colorScheme: {
             comment: {
               markdownText:
-                'The appearance color scheme the host CMS is currently using. Resolved —\n`\'system\'` is already expanded to `\'light\'` or `\'dark\'` by the host.\n\nThe SDK runtime reflects this onto `document.documentElement` as\n`data-theme="light"` / `data-theme="dark"` so plugin CSS can branch\nwith `[data-theme="dark"] { … }` selectors. For non-CSS decisions\n(choosing a logo asset, a syntax-highlighting preset, …) branch on\n`ctx.colorScheme` directly.',
+                'The appearance color scheme the host CMS is currently using. Resolved —\n`\'system\'` is already expanded to `\'light\'` or `\'dark\'` by the host.\n\nThe SDK runtime reflects this onto `document.documentElement` as\n`data-color-scheme="light"` / `data-color-scheme="dark"` so plugin CSS\ncan branch with `[data-color-scheme="dark"] { … }` selectors. For\nnon-CSS decisions\n(choosing a logo asset, a syntax-highlighting preset, …) branch on\n`ctx.colorScheme` directly.',
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 131,
+              lineNumber: 132,
             },
             type: "'light' | 'dark'",
           },
@@ -3409,7 +3409,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 141,
+              lineNumber: 142,
             },
             type: 'Partial<Record<string, ItemType>>',
           },
@@ -3420,7 +3420,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 148,
+              lineNumber: 149,
             },
             type: 'Partial<Record<string, Field>>',
           },
@@ -3431,7 +3431,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 155,
+              lineNumber: 156,
             },
             type: 'Partial<Record<string, Fieldset>>',
           },
@@ -3442,7 +3442,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 162,
+              lineNumber: 163,
             },
             type: 'Partial<Record<string, User>>',
           },
@@ -3453,7 +3453,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 169,
+              lineNumber: 170,
             },
             type: 'Partial<Record<string, SsoUser>>',
           },
@@ -3477,7 +3477,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 232,
+              lineNumber: 233,
             },
             type: '(itemTypeId: string) => Promise<Field[]>',
           },
@@ -3490,7 +3490,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 251,
+              lineNumber: 252,
             },
             type: '(itemTypeId: string) => Promise<Fieldset[]>',
           },
@@ -3503,7 +3503,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 268,
+              lineNumber: 269,
             },
             type: '() => Promise<Field[]>',
           },
@@ -3516,7 +3516,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 281,
+              lineNumber: 282,
             },
             type: '() => Promise<User[]>',
           },
@@ -3529,7 +3529,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 294,
+              lineNumber: 295,
             },
             type: '() => Promise<SsoUser[]>',
           },
@@ -3551,7 +3551,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 316,
+              lineNumber: 317,
             },
             type: '(params: Record<string, unknown>) => Promise<void>',
           },
@@ -3564,7 +3564,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 367,
+              lineNumber: 368,
             },
             type: '(\n    fieldId: string,\n    changes: FieldAppearanceChange[],\n  ) => Promise<void>',
           },
@@ -3586,7 +3586,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 472,
+              lineNumber: 473,
             },
             type: '(message: string) => Promise<void>',
           },
@@ -3599,7 +3599,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 487,
+              lineNumber: 488,
             },
             type: '(message: string) => Promise<void>',
           },
@@ -3612,7 +3612,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 511,
+              lineNumber: 512,
             },
             type: '<CtaValue = unknown>(\n    toast: Toast<CtaValue>,\n  ) => Promise<CtaValue | null>',
           },
@@ -3634,7 +3634,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 397,
+              lineNumber: 398,
             },
             type: '(itemTypeId: string) => Promise<Item | null>',
           },
@@ -3647,7 +3647,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 418,
+              lineNumber: 419,
             },
             type: '{\n    (\n      itemTypeId: string,\n      options: { multiple: true; initialLocationQuery?: ItemListLocationQuery },\n    ): Promise<Item[] | null>;\n    (\n      itemTypeId: string,\n      options?: {\n        multiple: false;\n        initialLocationQuery?: ItemListLocationQuery;\n      },\n    ): Promise<Item | null>;\n  }',
           },
@@ -3660,7 +3660,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 450,
+              lineNumber: 451,
             },
             type: '(itemId: string) => Promise<Item | null>',
           },
@@ -3682,7 +3682,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 538,
+              lineNumber: 539,
             },
             type: '{\n    (options: { multiple: true }): Promise<Upload[] | null>;\n    (options?: { multiple: false }): Promise<Upload | null>;\n  }',
           },
@@ -3695,7 +3695,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 566,
+              lineNumber: 567,
             },
             type: '(\n    uploadId: string,\n  ) => Promise<(Upload & { deleted?: true }) | null>',
           },
@@ -3708,7 +3708,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 594,
+              lineNumber: 595,
             },
             type: '(\n    /** The "single asset" field structure */\n    fileFieldValue: FileFieldValue,\n    /** Shows metadata information for a specific locale */\n    locale?: string,\n  ) => Promise<FileFieldValue | null>',
           },
@@ -3730,7 +3730,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 625,
+              lineNumber: 626,
             },
             type: '(modal: Modal) => Promise<unknown>',
           },
@@ -3743,7 +3743,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 662,
+              lineNumber: 663,
             },
             type: '(options: ConfirmOptions) => Promise<unknown>',
           },
@@ -3764,7 +3764,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 676,
+              lineNumber: 677,
             },
             type: '(path: string) => Promise<void>',
           },

--- a/packages/sdk/src/manifest.ts
+++ b/packages/sdk/src/manifest.ts
@@ -3362,12 +3362,36 @@ export const manifest: Manifest = {
             comment: {
               markdownText:
                 'An object containing the theme colors for the current DatoCMS project.',
+              deprecatedMarkdownText:
+                'Use `semanticColorTokensTheme` instead. This property is kept\nfor backward compatibility with third-party plugins.',
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 106,
+              lineNumber: 111,
             },
             type: 'Theme',
+          },
+          semanticColorTokensTheme: {
+            comment: {
+              markdownText:
+                'Semantic color tokens for the current DatoCMS project, pre-computed by\nthe host. A map of CSS custom property names (e.g.\n`--color--raised--surface`) to their resolved values for the current\ncolor scheme. Only available on DatoCMS hosts that support the new token\nsystem.',
+            },
+            location: {
+              filePath: 'src/ctx/base.ts',
+              lineNumber: 120,
+            },
+            type: 'SemanticColorTokensTheme',
+          },
+          colorScheme: {
+            comment: {
+              markdownText:
+                'The appearance color scheme the host CMS is currently using. Resolved —\n`\'system\'` is already expanded to `\'light\'` or `\'dark\'` by the host.\n\nThe SDK runtime reflects this onto `document.documentElement` as\n`data-theme="light"` / `data-theme="dark"` so plugin CSS can branch\nwith `[data-theme="dark"] { … }` selectors. For non-CSS decisions\n(choosing a logo asset, a syntax-highlighting preset, …) branch on\n`ctx.colorScheme` directly.',
+            },
+            location: {
+              filePath: 'src/ctx/base.ts',
+              lineNumber: 132,
+            },
+            type: "'light' | 'dark'",
           },
         },
       },
@@ -3385,7 +3409,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 116,
+              lineNumber: 142,
             },
             type: 'Partial<Record<string, ItemType>>',
           },
@@ -3396,7 +3420,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 123,
+              lineNumber: 149,
             },
             type: 'Partial<Record<string, Field>>',
           },
@@ -3407,7 +3431,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 130,
+              lineNumber: 156,
             },
             type: 'Partial<Record<string, Fieldset>>',
           },
@@ -3418,7 +3442,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 137,
+              lineNumber: 163,
             },
             type: 'Partial<Record<string, User>>',
           },
@@ -3429,7 +3453,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 144,
+              lineNumber: 170,
             },
             type: 'Partial<Record<string, SsoUser>>',
           },
@@ -3453,7 +3477,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 187,
+              lineNumber: 233,
             },
             type: '(itemTypeId: string) => Promise<Field[]>',
           },
@@ -3466,7 +3490,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 206,
+              lineNumber: 252,
             },
             type: '(itemTypeId: string) => Promise<Fieldset[]>',
           },
@@ -3479,7 +3503,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 223,
+              lineNumber: 269,
             },
             type: '() => Promise<Field[]>',
           },
@@ -3492,7 +3516,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 236,
+              lineNumber: 282,
             },
             type: '() => Promise<User[]>',
           },
@@ -3505,7 +3529,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 249,
+              lineNumber: 295,
             },
             type: '() => Promise<SsoUser[]>',
           },
@@ -3527,7 +3551,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 271,
+              lineNumber: 317,
             },
             type: '(params: Record<string, unknown>) => Promise<void>',
           },
@@ -3540,7 +3564,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 322,
+              lineNumber: 368,
             },
             type: '(\n    fieldId: string,\n    changes: FieldAppearanceChange[],\n  ) => Promise<void>',
           },
@@ -3562,7 +3586,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 427,
+              lineNumber: 473,
             },
             type: '(message: string) => Promise<void>',
           },
@@ -3575,7 +3599,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 442,
+              lineNumber: 488,
             },
             type: '(message: string) => Promise<void>',
           },
@@ -3588,7 +3612,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 466,
+              lineNumber: 512,
             },
             type: '<CtaValue = unknown>(\n    toast: Toast<CtaValue>,\n  ) => Promise<CtaValue | null>',
           },
@@ -3610,7 +3634,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 352,
+              lineNumber: 398,
             },
             type: '(itemTypeId: string) => Promise<Item | null>',
           },
@@ -3623,7 +3647,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 373,
+              lineNumber: 419,
             },
             type: '{\n    (\n      itemTypeId: string,\n      options: { multiple: true; initialLocationQuery?: ItemListLocationQuery },\n    ): Promise<Item[] | null>;\n    (\n      itemTypeId: string,\n      options?: {\n        multiple: false;\n        initialLocationQuery?: ItemListLocationQuery;\n      },\n    ): Promise<Item | null>;\n  }',
           },
@@ -3636,7 +3660,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 405,
+              lineNumber: 451,
             },
             type: '(itemId: string) => Promise<Item | null>',
           },
@@ -3658,7 +3682,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 493,
+              lineNumber: 539,
             },
             type: '{\n    (options: { multiple: true }): Promise<Upload[] | null>;\n    (options?: { multiple: false }): Promise<Upload | null>;\n  }',
           },
@@ -3671,7 +3695,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 521,
+              lineNumber: 567,
             },
             type: '(\n    uploadId: string,\n  ) => Promise<(Upload & { deleted?: true }) | null>',
           },
@@ -3684,7 +3708,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 549,
+              lineNumber: 595,
             },
             type: '(\n    /** The "single asset" field structure */\n    fileFieldValue: FileFieldValue,\n    /** Shows metadata information for a specific locale */\n    locale?: string,\n  ) => Promise<FileFieldValue | null>',
           },
@@ -3706,7 +3730,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 580,
+              lineNumber: 626,
             },
             type: '(modal: Modal) => Promise<unknown>',
           },
@@ -3719,7 +3743,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 617,
+              lineNumber: 663,
             },
             type: '(options: ConfirmOptions) => Promise<unknown>',
           },
@@ -3740,7 +3764,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 631,
+              lineNumber: 677,
             },
             type: '(path: string) => Promise<void>',
           },

--- a/packages/sdk/src/manifest.ts
+++ b/packages/sdk/src/manifest.ts
@@ -3360,6 +3360,17 @@ export const manifest: Manifest = {
             },
             type: 'SemanticColorTokensTheme',
           },
+          colorScheme: {
+            comment: {
+              markdownText:
+                'The appearance color scheme the host CMS is currently using. Resolved —\n`\'system\'` is already expanded to `\'light\'` or `\'dark\'` by the host.\n\nThe SDK runtime reflects this onto `document.documentElement` as\n`data-theme="light"` / `data-theme="dark"` so plugin CSS can branch\nwith `[data-theme="dark"] { … }` selectors. For non-CSS decisions\n(choosing a logo asset, a syntax-highlighting preset, …) branch on\n`ctx.colorScheme` directly.',
+            },
+            location: {
+              filePath: 'src/ctx/base.ts',
+              lineNumber: 111,
+            },
+            type: "'light' | 'dark'",
+          },
         },
       },
       {
@@ -3376,7 +3387,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 109,
+              lineNumber: 121,
             },
             type: 'Partial<Record<string, ItemType>>',
           },
@@ -3387,7 +3398,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 116,
+              lineNumber: 128,
             },
             type: 'Partial<Record<string, Field>>',
           },
@@ -3398,7 +3409,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 123,
+              lineNumber: 135,
             },
             type: 'Partial<Record<string, Fieldset>>',
           },
@@ -3409,7 +3420,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 130,
+              lineNumber: 142,
             },
             type: 'Partial<Record<string, User>>',
           },
@@ -3420,7 +3431,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 137,
+              lineNumber: 149,
             },
             type: 'Partial<Record<string, SsoUser>>',
           },
@@ -3444,7 +3455,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 341,
+              lineNumber: 353,
             },
             type: '(itemTypeId: string) => Promise<Field[]>',
           },
@@ -3457,7 +3468,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 360,
+              lineNumber: 372,
             },
             type: '(itemTypeId: string) => Promise<Fieldset[]>',
           },
@@ -3470,7 +3481,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 377,
+              lineNumber: 389,
             },
             type: '() => Promise<Field[]>',
           },
@@ -3483,7 +3494,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 390,
+              lineNumber: 402,
             },
             type: '() => Promise<User[]>',
           },
@@ -3496,7 +3507,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 403,
+              lineNumber: 415,
             },
             type: '() => Promise<SsoUser[]>',
           },
@@ -3518,7 +3529,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 425,
+              lineNumber: 437,
             },
             type: '(params: Record<string, unknown>) => Promise<void>',
           },
@@ -3531,7 +3542,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 476,
+              lineNumber: 488,
             },
             type: '(\n    fieldId: string,\n    changes: FieldAppearanceChange[],\n  ) => Promise<void>',
           },
@@ -3553,7 +3564,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 581,
+              lineNumber: 593,
             },
             type: '(message: string) => Promise<void>',
           },
@@ -3566,7 +3577,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 596,
+              lineNumber: 608,
             },
             type: '(message: string) => Promise<void>',
           },
@@ -3579,7 +3590,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 620,
+              lineNumber: 632,
             },
             type: '<CtaValue = unknown>(\n    toast: Toast<CtaValue>,\n  ) => Promise<CtaValue | null>',
           },
@@ -3601,7 +3612,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 506,
+              lineNumber: 518,
             },
             type: '(itemTypeId: string) => Promise<Item | null>',
           },
@@ -3614,7 +3625,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 527,
+              lineNumber: 539,
             },
             type: '{\n    (\n      itemTypeId: string,\n      options: { multiple: true; initialLocationQuery?: ItemListLocationQuery },\n    ): Promise<Item[] | null>;\n    (\n      itemTypeId: string,\n      options?: {\n        multiple: false;\n        initialLocationQuery?: ItemListLocationQuery;\n      },\n    ): Promise<Item | null>;\n  }',
           },
@@ -3627,7 +3638,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 559,
+              lineNumber: 571,
             },
             type: '(itemId: string) => Promise<Item | null>',
           },
@@ -3649,7 +3660,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 647,
+              lineNumber: 659,
             },
             type: '{\n    (options: { multiple: true }): Promise<Upload[] | null>;\n    (options?: { multiple: false }): Promise<Upload | null>;\n  }',
           },
@@ -3662,7 +3673,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 675,
+              lineNumber: 687,
             },
             type: '(\n    uploadId: string,\n  ) => Promise<(Upload & { deleted?: true }) | null>',
           },
@@ -3675,7 +3686,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 703,
+              lineNumber: 715,
             },
             type: '(\n    /** The "single asset" field structure */\n    fileFieldValue: FileFieldValue,\n    /** Shows metadata information for a specific locale */\n    locale?: string,\n  ) => Promise<FileFieldValue | null>',
           },
@@ -3697,7 +3708,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 734,
+              lineNumber: 746,
             },
             type: '(modal: Modal) => Promise<unknown>',
           },
@@ -3710,7 +3721,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 771,
+              lineNumber: 783,
             },
             type: '(options: ConfirmOptions) => Promise<unknown>',
           },
@@ -3731,7 +3742,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 785,
+              lineNumber: 797,
             },
             type: '(path: string) => Promise<void>',
           },


### PR DESCRIPTION
Adds a `semanticColorTokensTheme` field to the plugin SDK context, with a typed list of known tokens (surface/ink/border, plus per-context variants for primary/tinted/accent/selected/disabled/danger/highlight/etc., plus diff/status/overlay/stacked/progress/tooltip/code/shadow groups). The `Theme` field is preserved but marked deprecated for backward compat.

`generateStyleFromCtx` now emits these tokens as CSS custom properties (`--color--surface`, `--color--primary--ink`, etc.) on the Canvas root.

All react-ui components are migrated to consume the new tokens (Button, ButtonGroup, Dropdown, Section, TextInput, TextareaInput, SwitchInput, SidebarPanel, Toolbar, Tooltip, VerticalSplit, …).

For backward compatibility, the legacy color vars in `Canvas/styles.module.css` (`--border-color`, `--base-body-color`, `--alert-color`, `--add-color`, …) now resolve to the closest semantic token first, falling back to their original light-mode RGB values. The color block is marked `@deprecated` and slated for removal in a future major; spacing/font/easing tokens remain stable. `--spacing-xs` is added to complete the spacing scale.

Other touch-ups:
- `fill="currentColor"` on every shipped SVG icon so colors inherit
- SidebarPanel uses CaretDown/Up icons (matching the CMS)
- SwitchInput styles brought in line with the CMS (off-track ink-muted, primary--ink/surface for checked, smoother knob transitions)
- Fix broken `var(--border-radius-m)` reference in TooltipDelayGroup JSDoc example