### PR TITLE
Add poster_time to file field value types

### DIFF
--- a/packages/sdk/manifest.json
+++ b/packages/sdk/manifest.json
@@ -3426,11 +3426,11 @@
           "editUploadMetadata": {
             "comment": {
               "markdownText": "Opens a dialog for editing a \"single asset\" field structure. It returns a\npromise resolved with the updated structure, or `null` if the user closes\nthe dialog without persisting any change.",
-              "example": "const uploadId = prompt('Please insert an asset ID:');\n\nconst result = await ctx.editUploadMetadata({\n  upload_id: uploadId,\n  alt: null,\n  title: null,\n  custom_data: {},\n  focal_point: null,\n});\n\nif (result) {\n  ctx.notice(`Success! ${JSON.stringify(result)}`);\n} else {\n  ctx.alert('Closed!');\n}"
+              "example": "const uploadId = prompt('Please insert an asset ID:');\n\nconst result = await ctx.editUploadMetadata({\n  upload_id: uploadId,\n  alt: null,\n  title: null,\n  custom_data: {},\n  focal_point: null,\n  poster_time: null,\n});\n\nif (result) {\n  ctx.notice(`Success! ${JSON.stringify(result)}`);\n} else {\n  ctx.alert('Closed!');\n}"
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 597
+              "lineNumber": 598
             },
             "type": "(\n    /** The \"single asset\" field structure */\n    fileFieldValue: FileFieldValue,\n    /** Shows metadata information for a specific locale */\n    locale?: string,\n  ) => Promise<FileFieldValue | null>"
           }
@@ -3449,7 +3449,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 628
+              "lineNumber": 629
             },
             "type": "(modal: Modal) => Promise<unknown>"
           },
@@ -3460,7 +3460,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 665
+              "lineNumber": 666
             },
             "type": "(options: ConfirmOptions) => Promise<unknown>"
           }
@@ -3479,7 +3479,7 @@
             },
             "location": {
               "filePath": "src/ctx/base.ts",
-              "lineNumber": 679
+              "lineNumber": 680
             },
             "type": "(path: string) => Promise<void>"
           }

--- a/packages/sdk/src/ctx/base.ts
+++ b/packages/sdk/src/ctx/base.ts
@@ -585,6 +585,7 @@ type UploadDialogMethods = {
    *   title: null,
    *   custom_data: {},
    *   focal_point: null,
+   *   poster_time: null,
    * });
    *
    * if (result) {
@@ -758,6 +759,9 @@ export type FileFieldValue = {
   /** Object with arbitrary metadata related to the asset */
   // eslint-disable-next-line camelcase
   custom_data: Record<string, string>;
+  /** Poster time in seconds (only for video assets) */
+  // eslint-disable-next-line camelcase
+  poster_time: number | null;
 };
 
 /** A modal to present to the user */

--- a/packages/sdk/src/hooks/renderAssetSource.ts
+++ b/packages/sdk/src/hooks/renderAssetSource.ts
@@ -102,6 +102,8 @@ export type NewUpload = {
         /** Vertical position expressed as float between 0 and 1 */
         y: number;
       } | null;
+      /** Poster time in seconds (only for video assets) */
+      poster_time?: number | null;
     };
   };
 };

--- a/packages/sdk/src/manifest.ts
+++ b/packages/sdk/src/manifest.ts
@@ -3704,11 +3704,11 @@ export const manifest: Manifest = {
               markdownText:
                 'Opens a dialog for editing a "single asset" field structure. It returns a\npromise resolved with the updated structure, or `null` if the user closes\nthe dialog without persisting any change.',
               example:
-                "const uploadId = prompt('Please insert an asset ID:');\n\nconst result = await ctx.editUploadMetadata({\n  upload_id: uploadId,\n  alt: null,\n  title: null,\n  custom_data: {},\n  focal_point: null,\n});\n\nif (result) {\n  ctx.notice(`Success! ${JSON.stringify(result)}`);\n} else {\n  ctx.alert('Closed!');\n}",
+                "const uploadId = prompt('Please insert an asset ID:');\n\nconst result = await ctx.editUploadMetadata({\n  upload_id: uploadId,\n  alt: null,\n  title: null,\n  custom_data: {},\n  focal_point: null,\n  poster_time: null,\n});\n\nif (result) {\n  ctx.notice(`Success! ${JSON.stringify(result)}`);\n} else {\n  ctx.alert('Closed!');\n}",
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 597,
+              lineNumber: 598,
             },
             type: '(\n    /** The "single asset" field structure */\n    fileFieldValue: FileFieldValue,\n    /** Shows metadata information for a specific locale */\n    locale?: string,\n  ) => Promise<FileFieldValue | null>',
           },
@@ -3730,7 +3730,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 628,
+              lineNumber: 629,
             },
             type: '(modal: Modal) => Promise<unknown>',
           },
@@ -3743,7 +3743,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 665,
+              lineNumber: 666,
             },
             type: '(options: ConfirmOptions) => Promise<unknown>',
           },
@@ -3764,7 +3764,7 @@ export const manifest: Manifest = {
             },
             location: {
               filePath: 'src/ctx/base.ts',
-              lineNumber: 679,
+              lineNumber: 680,
             },
             type: '(path: string) => Promise<void>',
           },


### PR DESCRIPTION
Adds `poster_time` to the plugin SDK file-field types, mirroring `@datocms/cma-client` v5.5.4.

- `FileFieldValue` (`ctx/base.ts`): `poster_time: number | null` — required, matching the CMA client and the host runtime, which always provides it (default `null`).
- `NewUpload.default_field_metadata` (`hooks/renderAssetSource.ts`): `poster_time?: number | null` — optional, request-side, consistent with the already-optional `focal_point`.
- Regenerated `manifest.json` / `manifest.ts`.

The DatoCMS host app already passes `poster_time` to plugins at runtime; this just adds the typing.