### PR TITLE
Fix SwitchField label not toggling the switch

### DIFF
--- a/packages/react-ui/src/SwitchField/index.tsx
+++ b/packages/react-ui/src/SwitchField/index.tsx
@@ -41,6 +41,7 @@ export function SwitchField({
         <div className={s.switchField__switchInput}>
           <SwitchInput
             {...switchInputProps}
+            id={id}
             name={name}
             value={value}
             onChange={onChange}

--- a/packages/react-ui/src/SwitchField/index.tsx
+++ b/packages/react-ui/src/SwitchField/index.tsx
@@ -51,7 +51,11 @@ export function SwitchField({
           {...formLabelProps}
           htmlFor={id}
           required={required}
-          className={cn(s.switchField__label, formLabelProps?.className)}
+          className={cn(
+            s.switchField__label,
+            switchInputProps?.disabled && s['switchField__label--disabled'],
+            formLabelProps?.className,
+          )}
           error={!!error}
         >
           {label}

--- a/packages/react-ui/src/SwitchField/styles.module.css
+++ b/packages/react-ui/src/SwitchField/styles.module.css
@@ -11,7 +11,6 @@
   line-height: 1.1;
   flex: 1;
   line-height: 20px;
-  pointer-events: none;
   -moz-user-select: text;
   -ms-user-select: text;
   user-select: text;

--- a/packages/react-ui/src/SwitchField/styles.module.css
+++ b/packages/react-ui/src/SwitchField/styles.module.css
@@ -8,14 +8,16 @@
 }
 
 .switchField__label {
-  line-height: 1.1;
   flex: 1;
   line-height: 20px;
-  -moz-user-select: text;
-  -ms-user-select: text;
-  user-select: text;
   margin-bottom: 0;
   color: var(--color--ink);
+
+  /* Match the button cursors */
+  cursor: pointer;
+  &--disabled {
+    cursor: no-drop;
+  }
 }
 
 .switchField__below {


### PR DESCRIPTION
Fixes #42

## Problem

`SwitchField` renders its `FormLabel` with `htmlFor={id}`, but that `id` is never forwarded to the `SwitchInput` button. As a result the label's `for` attribute points at a non-existent element, so clicking the label does nothing — unlike native checkboxes (and legacy DatoCMS plugins), where clicking the label toggles the control and enlarges the clickable area.

## Fix

Forward `id={id}` to the `SwitchInput`. Since `<button>` is a labelable element, this restores the native label/control association, so clicking the label toggles the switch again. `SwitchInput` already spreads unknown props onto its `<button>`, so no other change is needed.

```diff
           <SwitchInput
             {...switchInputProps}
+            id={id}
             name={name}
             value={value}
             onChange={onChange}
```

## Verification

With the `id` in place, the label's `for` matches the button's `id`, the label resolves to the button as its associated control, and a click on the label triggers `onChange`. Without it, the label has no associated control and the click is a no-op.