### PR TITLE
Publish a preview of both packages on every push

### DIFF
--- a/.github/workflows/continuous-releases.yml
+++ b/.github/workflows/continuous-releases.yml
@@ -1,0 +1,44 @@
+# Every commit pushed to a branch of this repo gets an installable preview of
+# every package, without publishing anything to npm:
+#
+#     npm i https://pkg.pr.new/datocms-plugin-sdk@<commit-sha>
+#
+# The point is to cross a repo boundary while developing. A change here can be
+# tried inside a consumer that lives in another repository — `cms`, a demo, a
+# customer project — from a real tarball, instead of `npm link` or pinning a
+# git branch by hand and remembering to unpin it later. Installing one preview
+# pulls in the previews of its siblings from the same commit, so a change that
+# spans several packages is tried as one coherent set.
+#
+# Pull requests opened from forks are deliberately not published: this runs on
+# pushes to branches of *this* repo, which only people with write access can
+# make, so an unreviewed fork cannot mint a URL under our namespace. If we ever
+# want fork previews too, pkg.pr.new documents an "approved pull requests only"
+# recipe that gates them behind a maintainer's review.
+name: Continuous releases
+
+on:
+  push:
+    # Every branch. Defining `branches` on its own also means tag pushes don't
+    # trigger this, which is what we want: a tag points at a commit that was
+    # already published when it landed on its branch.
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+      - name: Use Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build
+      # Once for all the packages, not once per package: pkg.pr.new expects a
+      # single invocation per workflow run, and rejects the rest as spam.
+      - run: npm exec -- pkg-pr-new publish --commentWithSha './packages/*'

--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ From there, the [Plugin SDK documentation](https://www.datocms.com/docs/plugin-s
 
 To work on the packages themselves (e.g. to prepare a PR or debug an issue in the framework itself), see the "Developing" section of each package's README: [`datocms-plugin-sdk`](https://github.com/datocms/plugins-sdk/blob/master/packages/sdk/README.md#developing), [`datocms-react-ui`](https://github.com/datocms/plugins-sdk/blob/master/packages/react-ui/README.md#developing). Both are developed in this npm-workspaces monorepo, and share a version number whenever they are released together.
 
+## Trying a change before it's released
+
+Every push to a branch here publishes a preview of both packages, which you can
+install into a real plugin — no npm release, no `npm link`:
+
+```
+npm i https://pkg.pr.new/datocms-plugin-sdk@<commit-sha>
+npm i https://pkg.pr.new/datocms-react-ui@<commit-sha>
+```
+
+The exact URLs show up in the commit's check run on GitHub, and in a comment on
+the pull request once there is one. Installing one preview pulls in the previews
+of its siblings built from the same commit, so a change spanning several
+packages can be tried as one coherent set.
+
+Previews are throwaway: they are never published to npm, and the URL stops
+resolving after a while. Never commit one to a `package.json` that ships.
+
 ## Releasing
 
 Maintainers only. The two packages share one version number and are always

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@typescript-eslint/parser": "^5.42.0",
         "husky": "^9.0.11",
         "jest": "^29.2.2",
+        "pkg-pr-new": "^0.0.88",
         "ts-jest": "^29.0.3",
         "tsx": "^4.19.1",
         "turbo": "^2.10.11",
@@ -8047,6 +8048,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkg-pr-new": {
+      "version": "0.0.88",
+      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.88.tgz",
+      "integrity": "sha512-Xc6PMJ2gher0WZP+rtjefFk26hIb7V1PTLL30bmy1Z2vsRmSvqiss7Ag1XUdyplTGYzIlFNJp4L3vMNmK44N6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pkg-pr-new": "bin/cli.js"
       }
     },
     "node_modules/postcss": {
@@ -16202,6 +16213,12 @@
       "requires": {
         "find-up": "^4.0.0"
       }
+    },
+    "pkg-pr-new": {
+      "version": "0.0.88",
+      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.88.tgz",
+      "integrity": "sha512-Xc6PMJ2gher0WZP+rtjefFk26hIb7V1PTLL30bmy1Z2vsRmSvqiss7Ag1XUdyplTGYzIlFNJp4L3vMNmK44N6g==",
+      "dev": true
     },
     "postcss": {
       "version": "8.5.26",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@typescript-eslint/parser": "^5.42.0",
     "husky": "^9.0.11",
     "jest": "^29.2.2",
+    "pkg-pr-new": "^0.0.88",
     "ts-jest": "^29.0.3",
     "tsx": "^4.19.1",
     "turbo": "^2.10.11",


### PR DESCRIPTION
Every commit pushed to a branch here now produces installable tarballs of both
packages, without publishing anything to npm:

```
npm i https://pkg.pr.new/datocms-plugin-sdk@<commit-sha>
npm i https://pkg.pr.new/datocms-react-ui@<commit-sha>
```

## Why

This one matters more than for the other repos: the only real test of an SDK
change is a plugin using it, and every plugin lives in a different repository —
ours in `datocms/plugins`, everyone else's in their own. Today that means
cutting a release, or `npm link`, which is exactly the friction that makes us
batch SDK changes instead of shipping them.

Now a plugin author can be handed a URL to try a fix before we release it.

## Verified on this branch

The run on 71e3354 published both. Installed into a throwaway project:

```
datocms-react-ui                → pkg.pr.new     (this repo)
datocms-plugin-sdk              → pkg.pr.new     (this repo)
@datocms/cma-client             → registry.npmjs.org
datocms-structured-text-utils   → registry.npmjs.org
react, react-select, …          → registry.npmjs.org
```

Installing `datocms-react-ui` alone pulls in the `datocms-plugin-sdk` preview
built from the same commit, so a change touching both is tried as one set.

## Choices worth reviewing

**Pushes only, no fork pull requests.** The workflow runs on pushes to branches
of this repo, which only people with write access can make. This is deliberate:
pkg.pr.new URLs carry our namespace and the tarballs are served
unauthenticated, so an unreviewed fork should not be able to mint one.
pkg.pr.new documents an "approved pull requests only" recipe if we want fork
previews later — plausibly worth it here, given plugin authors do send PRs.

**A separate workflow, not a step in `node.js.yml`.** That one runs a matrix of
two Node versions; pkg-pr-new must run exactly once per workflow run.

**No changeset.** Nothing about the published packages changes.

## One thing to know

Previews are throwaway and the URLs stop resolving after a while. They must
never end up in a `package.json` that ships.